### PR TITLE
Update Carthage instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,7 @@ For installation details please see the next points.
 
 #### via Carthage
 
-You can use [Carthage](https://github.com/Carthage/Carthage
-
-``` 
-                   ) to install SwiftyBeaver by adding that to your Cartfile:
-```
+You can use [Carthage](https://github.com/Carthage/Carthage) to install SwiftyBeaver by adding that to your Cartfile:
 
 ``` 
 github "SwiftyBeaver/SwiftyBeaver"


### PR DESCRIPTION
The Carthage instructions had some extra back ticks that broke the Markdown rendering of the Carthage URL.