### PR TITLE
Allow BaseDestination to be overridden

### DIFF
--- a/sources/BaseDestination.swift
+++ b/sources/BaseDestination.swift
@@ -49,7 +49,7 @@ public class BaseDestination: Hashable, Equatable {
 
     // each destination class must have an own hashValue Int
     lazy public var hashValue: Int = self.defaultHashValue
-    var defaultHashValue: Int {return 0}
+    public var defaultHashValue: Int {return 0}
     
     // each destination instance must have an own serial queue to ensure serial output
     // GCD gives it a prioritization between User Initiated and Utility
@@ -70,7 +70,7 @@ public class BaseDestination: Hashable, Equatable {
     /// send / store the formatted log message to the destination
     /// returns the formatted log message for processing by inheriting method
     /// and for unit tests (nil if error)
-    func send(level: SwiftyBeaver.Level, msg: String, thread: String, path: String, function: String, line: Int) -> String? {
+    public func send(level: SwiftyBeaver.Level, msg: String, thread: String, path: String, function: String, line: Int) -> String? {
         var dateStr = ""
         var str = ""
         let levelStr = formattedLevel(level)

--- a/sources/BaseDestination.swift
+++ b/sources/BaseDestination.swift
@@ -55,7 +55,7 @@ public class BaseDestination: Hashable, Equatable {
     // GCD gives it a prioritization between User Initiated and Utility
     var queue: dispatch_queue_t?
     
-    init() {
+    public init() {
         let uuid = NSUUID().UUIDString
         let queueLabel = "swiftybeaver-queue-" + uuid
         queue = dispatch_queue_create(queueLabel, nil)

--- a/sources/ConsoleDestination.swift
+++ b/sources/ConsoleDestination.swift
@@ -11,14 +11,14 @@ import Foundation
 
 public class ConsoleDestination: BaseDestination {
     
-    override var defaultHashValue: Int {return 1}
+    override public var defaultHashValue: Int {return 1}
     
     public override init() {
         super.init()
     }
     
     // print to Xcode Console. uses full base class functionality
-    override func send(level: SwiftyBeaver.Level, msg: String, thread: String, path: String, function: String, line: Int) -> String? {
+    override public func send(level: SwiftyBeaver.Level, msg: String, thread: String, path: String, function: String, line: Int) -> String? {
         let formattedString = super.send(level, msg: msg, thread: thread, path: path, function: function, line: line)
         
         if let str = formattedString {

--- a/sources/FileDestination.swift
+++ b/sources/FileDestination.swift
@@ -13,7 +13,7 @@ public class FileDestination: BaseDestination {
     
     public var logFileURL: NSURL
 
-    override var defaultHashValue: Int {return 2}
+    override public var defaultHashValue: Int {return 2}
     let fileManager = NSFileManager.defaultManager()
     
     public override init() {
@@ -37,7 +37,7 @@ public class FileDestination: BaseDestination {
     }
     
     // append to file. uses full base class functionality
-    override func send(level: SwiftyBeaver.Level, msg: String, thread: String, path: String, function: String, line: Int) -> String? {
+    override public func send(level: SwiftyBeaver.Level, msg: String, thread: String, path: String, function: String, line: Int) -> String? {
         let formattedString = super.send(level, msg: msg, thread: thread, path: path, function: function, line: line)
         
         if let str = formattedString {


### PR DESCRIPTION
Allow `BaseDestination` to be overridden by making overridable methods `public`. Swift’s default is `internal` which means that subclasses in a different module cannot override those methods.

This is important because the best way to import Swift dependencies is to link against dynamic frameworks.