### PR TITLE
add flush option

### DIFF
--- a/SwiftyBeaver.podspec
+++ b/SwiftyBeaver.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SwiftyBeaver"
-  s.version      = "0.3.2prenagha"
+  s.version      = "0.3.2"
   s.summary      = "Colorful, lightweight & fast logging in Swift 2"
 
   # This description is used to generate tags and improve search results.

--- a/SwiftyBeaver.podspec
+++ b/SwiftyBeaver.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SwiftyBeaver"
-  s.version      = "0.3.2"
+  s.version      = "0.3.2prenagha"
   s.summary      = "Colorful, lightweight & fast logging in Swift 2"
 
   # This description is used to generate tags and improve search results.

--- a/sources/SwiftyBeaver.swift
+++ b/sources/SwiftyBeaver.swift
@@ -112,4 +112,26 @@ public class SwiftyBeaver {
             }
         }
     }
+
+  /**
+   Flush all destinations to make sure all logging messages have been written out
+   Returns after all messages flushed or timeout seconds
+
+   - returns: true if all messages flushed, false if timeout occurred
+   */
+  public class func flush(secondTimeout: Int64) -> Bool {
+    let grp = dispatch_group_create();
+    for dest in destinations {
+      if let queue = dest.queue {
+        print("found \(queue.description)")
+        dispatch_group_enter(grp)
+        dispatch_async(queue, {
+          print("flushed \(queue.description)")
+          dispatch_group_leave(grp)
+        })
+      }
+    }
+    let waitUntil = dispatch_time(DISPATCH_TIME_NOW, secondTimeout * 1000000000)
+    return dispatch_group_wait(grp, waitUntil) == 0
+  }
 }

--- a/sources/SwiftyBeaver.swift
+++ b/sources/SwiftyBeaver.swift
@@ -123,10 +123,8 @@ public class SwiftyBeaver {
     let grp = dispatch_group_create();
     for dest in destinations {
       if let queue = dest.queue {
-        print("found \(queue.description)")
         dispatch_group_enter(grp)
         dispatch_async(queue, {
-          print("flushed \(queue.description)")
           dispatch_group_leave(grp)
         })
       }


### PR DESCRIPTION
I have a command line program I am using Swifty Beaver in, my problem was the main thread ends and the last log entry or two never gets written. That was because those messages were on the background queue and hadn't been processed yet. So I added a simple flush method with timeout to the top level object. It uses a dispatch group to keep track of how many destinations are sent a flush message, the flush message reducing the dispatch group. then a wait, which will block until the flush messages are processed or the timeout is reached.
testing in my prenagha/alamofire-example project and seems to work well
thought others might find it useful