### PR TITLE
Changes log functions to take an @autoclosure

### DIFF
--- a/SwiftyBeaverTests/SwiftyBeaverTests.swift
+++ b/SwiftyBeaverTests/SwiftyBeaverTests.swift
@@ -185,4 +185,26 @@ class SwiftyBeaverTests: XCTestCase {
         
         XCTAssertEqual(log.countDestinations(), 1)
     }
+    
+    func testLongRunningTaskIsNotExecutedWhenLoggingUnderMinLevel() {
+        
+        let log = SwiftyBeaver.self
+        
+        // add console
+        let console = ConsoleDestination()
+        console.dateFormat = "HH:mm:ss.SSS"
+        // set info level on default
+        console.minLevel = .Info
+        
+        log.addDestination(console)
+
+        func longRunningTask() -> CustomStringConvertible {
+            XCTAssert(false, "A block passed should not be executed if the log should not be logged.")
+            return "This should NOT BE VISIBLE!"
+        }
+        
+        log.verbose(longRunningTask())
+        
+    }
+    
 }

--- a/SwiftyBeaverTests/SwiftyBeaverTests.swift
+++ b/SwiftyBeaverTests/SwiftyBeaverTests.swift
@@ -198,13 +198,12 @@ class SwiftyBeaverTests: XCTestCase {
         
         log.addDestination(console)
 
-        func longRunningTask() -> CustomStringConvertible {
+        func longRunningTask() -> String {
             XCTAssert(false, "A block passed should not be executed if the log should not be logged.")
             return "This should NOT BE VISIBLE!"
         }
         
         log.verbose(longRunningTask())
-        
     }
     
 }

--- a/sources/SwiftyBeaver.swift
+++ b/sources/SwiftyBeaver.swift
@@ -76,33 +76,33 @@ public class SwiftyBeaver {
     
     // MARK: Levels
     
-    public class func verbose(@autoclosure message: () -> CustomStringConvertible, _ path: String = __FILE__, _ function: String = __FUNCTION__, line: Int = __LINE__) {
+    public class func verbose(@autoclosure message: () -> Any, _ path: String = __FILE__, _ function: String = __FUNCTION__, line: Int = __LINE__) {
         dispatch_send(Level.Verbose, message: message, thread: threadName(), path: path, function: function, line: line)
     }
 
-    public class func debug(@autoclosure message: () -> CustomStringConvertible, _ path: String = __FILE__, _ function: String = __FUNCTION__, line: Int = __LINE__) {
+    public class func debug(@autoclosure message: () -> Any, _ path: String = __FILE__, _ function: String = __FUNCTION__, line: Int = __LINE__) {
         dispatch_send(Level.Debug, message: message, thread: threadName(), path: path, function: function, line: line)
     }
     
-    public class func info(@autoclosure message: () -> CustomStringConvertible, _ path: String = __FILE__, _ function: String = __FUNCTION__, line: Int = __LINE__) {
+    public class func info(@autoclosure message: () -> Any, _ path: String = __FILE__, _ function: String = __FUNCTION__, line: Int = __LINE__) {
         dispatch_send(Level.Info, message: message, thread: threadName(), path: path, function: function, line: line)
     }
     
-    public class func warning(@autoclosure message: () -> CustomStringConvertible, _ path: String = __FILE__, _ function: String = __FUNCTION__, line: Int = __LINE__) {
+    public class func warning(@autoclosure message: () -> Any, _ path: String = __FILE__, _ function: String = __FUNCTION__, line: Int = __LINE__) {
         dispatch_send(Level.Warning, message: message, thread: threadName(), path: path, function: function, line: line)
     }
     
-    public class func error(@autoclosure message: () -> CustomStringConvertible, _ path: String = __FILE__, _ function: String = __FUNCTION__, line: Int = __LINE__) {
+    public class func error(@autoclosure message: () -> Any, _ path: String = __FILE__, _ function: String = __FUNCTION__, line: Int = __LINE__) {
         dispatch_send(Level.Error, message: message, thread: threadName(), path: path, function: function, line: line)
     }
     
     /// internal helper which dispatches send to dedicated queue if minLevel is ok
-    class func dispatch_send(level: SwiftyBeaver.Level, @autoclosure message: () -> CustomStringConvertible, thread: String, path: String, function: String, line: Int) {
+    class func dispatch_send(level: SwiftyBeaver.Level, @autoclosure message: () -> Any, thread: String, path: String, function: String, line: Int) {
         for dest in destinations {
             if let queue = dest.queue {
                 if dest.shouldLevelBeLogged(level, path: path, function: function) && dest.queue != nil {
                     // try to convert msg object to String and put it on queue
-                    let msgStr = message().description
+                    let msgStr = "\(message())"
                     if msgStr.characters.count > 0 {
                         dispatch_async(queue, {
                             dest.send(level, msg: msgStr, thread: thread, path: path, function: function, line: line)

--- a/sources/SwiftyBeaver.swift
+++ b/sources/SwiftyBeaver.swift
@@ -76,33 +76,33 @@ public class SwiftyBeaver {
     
     // MARK: Levels
     
-    public class func verbose(msg: Any, _ path: String = __FILE__, _ function: String = __FUNCTION__, line: Int = __LINE__) {
-        dispatch_send(Level.Verbose, msg: msg, thread: threadName(), path: path, function: function, line: line)
+    public class func verbose(@autoclosure message: () -> CustomStringConvertible, _ path: String = __FILE__, _ function: String = __FUNCTION__, line: Int = __LINE__) {
+        dispatch_send(Level.Verbose, message: message, thread: threadName(), path: path, function: function, line: line)
     }
 
-    public class func debug(msg: Any, _ path: String = __FILE__, _ function: String = __FUNCTION__, line: Int = __LINE__) {
-        dispatch_send(Level.Debug, msg: msg, thread: threadName(), path: path, function: function, line: line)
+    public class func debug(@autoclosure message: () -> CustomStringConvertible, _ path: String = __FILE__, _ function: String = __FUNCTION__, line: Int = __LINE__) {
+        dispatch_send(Level.Debug, message: message, thread: threadName(), path: path, function: function, line: line)
     }
     
-    public class func info(msg: Any, _ path: String = __FILE__, _ function: String = __FUNCTION__, line: Int = __LINE__) {
-        dispatch_send(Level.Info, msg: msg, thread: threadName(), path: path, function: function, line: line)
+    public class func info(@autoclosure message: () -> CustomStringConvertible, _ path: String = __FILE__, _ function: String = __FUNCTION__, line: Int = __LINE__) {
+        dispatch_send(Level.Info, message: message, thread: threadName(), path: path, function: function, line: line)
     }
     
-    public class func warning(msg: Any, _ path: String = __FILE__, _ function: String = __FUNCTION__, line: Int = __LINE__) {
-        dispatch_send(Level.Warning, msg: msg, thread: threadName(), path: path, function: function, line: line)
+    public class func warning(@autoclosure message: () -> CustomStringConvertible, _ path: String = __FILE__, _ function: String = __FUNCTION__, line: Int = __LINE__) {
+        dispatch_send(Level.Warning, message: message, thread: threadName(), path: path, function: function, line: line)
     }
     
-    public class func error(msg: Any, _ path: String = __FILE__, _ function: String = __FUNCTION__, line: Int = __LINE__) {
-        dispatch_send(Level.Error, msg: msg, thread: threadName(), path: path, function: function, line: line)
+    public class func error(@autoclosure message: () -> CustomStringConvertible, _ path: String = __FILE__, _ function: String = __FUNCTION__, line: Int = __LINE__) {
+        dispatch_send(Level.Error, message: message, thread: threadName(), path: path, function: function, line: line)
     }
     
     /// internal helper which dispatches send to dedicated queue if minLevel is ok
-    class func dispatch_send(level: SwiftyBeaver.Level, msg: Any, thread: String, path: String, function: String, line: Int) {
+    class func dispatch_send(level: SwiftyBeaver.Level, @autoclosure message: () -> CustomStringConvertible, thread: String, path: String, function: String, line: Int) {
         for dest in destinations {
             if let queue = dest.queue {
                 if dest.shouldLevelBeLogged(level, path: path, function: function) && dest.queue != nil {
                     // try to convert msg object to String and put it on queue
-                    let msgStr = "\(msg)"
+                    let msgStr = message().description
                     if msgStr.characters.count > 0 {
                         dispatch_async(queue, {
                             dest.send(level, msg: msgStr, thread: thread, path: path, function: function, line: line)


### PR DESCRIPTION
This changes the log functions to have signatures like:

```
public class func error(@autoclosure message: () -> CustomStringConvertible, _ path: String = __FILE__, _ function: String = __FUNCTION__, line: Int = __LINE__)
```

This change would break any code where someone was passing in an object that does not conform to `CustomStringConvertible`.