### PR TITLE
Log colors made public and editable

### DIFF
--- a/SwiftyBeaverTests/SwiftyBeaverTests.swift
+++ b/SwiftyBeaverTests/SwiftyBeaverTests.swift
@@ -121,7 +121,6 @@ class SwiftyBeaverTests: XCTestCase {
         log.debug("this should be in both files, msg 1")
         log.info("this should be in both files, msg 2")
     }
-
     
     func testColors() {
         let log = SwiftyBeaver.self
@@ -130,6 +129,8 @@ class SwiftyBeaverTests: XCTestCase {
         // add console
         let console = ConsoleDestination()
         log.addDestination(console)
+        
+        // add file
         let file = FileDestination()
         file.logFileURL = NSURL(string: "file:///tmp/testSwiftyBeaver.log")!
         file.detailOutput = false
@@ -144,7 +145,31 @@ class SwiftyBeaverTests: XCTestCase {
         log.info("a nice information")
         log.warning("oh no, that won’t be good")
         log.error("ouch, an error did occur!")
+
         XCTAssertEqual(log.countDestinations(), 2)
+    }
+    
+    func testModifiedColors() {
+        let log = SwiftyBeaver.self
+
+        // add console
+        let console = ConsoleDestination()
+        log.addDestination(console)
+
+        XCTAssertTrue(console.colored)
+
+        // change default color
+        console.levelColor.Verbose = "fg255,0,255;"
+        console.levelColor.Debug = "fg255,100,0;"
+        console.levelColor.Info = ""
+        console.levelColor.Warning = "fg255,255,255;"
+        console.levelColor.Error = "fg100,0,200;"
+        
+        log.verbose("not so important, level in magenta")
+        log.debug("something to debug, level in orange")
+        log.info("a nice information, level in black")
+        log.warning("oh no, that won’t be good, level in white")
+        log.error("ouch, an error did occur!, level in purple")
     }
     
     func testDifferentMessageTypes() {

--- a/sources/BaseDestination.swift
+++ b/sources/BaseDestination.swift
@@ -22,6 +22,7 @@ public class BaseDestination: Hashable, Equatable {
     public var minLevel = SwiftyBeaver.Level.Verbose
     public var dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
     public var levelString = LevelString()
+    public var levelColor = LevelColor()
     
     public struct LevelString {
         public var Verbose = "VERBOSE"
@@ -31,21 +32,21 @@ public class BaseDestination: Hashable, Equatable {
         public var Error = "ERROR"
     }
     
+    // For a colored log level word in a logged line
+    // XCode RGB colors
+    public struct LevelColor {
+        public var Verbose = "fg200,200,200;"     // silver
+        public var Debug = "fg0,0,255;"           // blue
+        public var Info = "fg0,255,0;"            // green
+        public var Warning = "fg255,255,0;"       // yellow
+        public var Error = "fg255,0,0;"           // red
+    }
+    
     var minLevelFilters = [MinLevelFilter]()
     let formatter = NSDateFormatter()
 
-    // For a colored log level word in a logged line
-    // XCode RGB colors
-    var blue = "fg0,0,255;"
-    var green = "fg0,255,0;"
-    var yellow = "fg255,255,0;"
-    var red = "fg255,0,0;"
-    var magenta = "fg255,0,255;"
-    var cyan = "fg0,255,255;"
-    var silver = "fg200,200,200;"
     var reset = "\u{001b}[;"
     var escape = "\u{001b}["
-
 
     // each destination class must have an own hashValue Int
     lazy public var hashValue: Int = self.defaultHashValue
@@ -97,24 +98,24 @@ public class BaseDestination: Hashable, Equatable {
         
         switch level {
         case SwiftyBeaver.Level.Debug:
-            color = blue
+            color = levelColor.Debug
             levelStr = levelString.Debug
             
         case SwiftyBeaver.Level.Info:
-            color = green
+            color = levelColor.Info
             levelStr = levelString.Info
             
         case SwiftyBeaver.Level.Warning:
-            color = yellow
+            color = levelColor.Warning
             levelStr = levelString.Warning
             
         case SwiftyBeaver.Level.Error:
-            color = red
+            color = levelColor.Error
             levelStr = levelString.Error
 
         default:
             // Verbose is default
-            color = silver
+            color = levelColor.Verbose
             levelStr = levelString.Verbose
         }
         

--- a/sources/FileDestination.swift
+++ b/sources/FileDestination.swift
@@ -27,13 +27,13 @@ public class FileDestination: BaseDestination {
         
         // bash font color, first value is intensity, second is color
         // see http://bit.ly/1Otu3Zr to learn more
-        blue = "0;34m"  // replace first 0 with 1 to make it bold
-        green = "0;32m"
-        yellow = "0;33m"
-        red = "0;31m"
-        magenta = "0;35m"
-        cyan = "0;36m"
-        silver = "0;37m"
+        // replace first 0 with 1 to make it bold
+        levelColor.Verbose = "0;37m"
+        levelColor.Debug = "0;34m"
+        levelColor.Info = "0;32m"
+        levelColor.Warning = "0;33m"
+        levelColor.Error = "0;31m"
+        
         reset = "\u{001b}[0m"
     }
     


### PR DESCRIPTION
With a white XCode background some colors like yellow are unreadable. With this change the user can modify log colors.