### PR TITLE
Flush hook for each destination

### DIFF
--- a/sources/BaseDestination.swift
+++ b/sources/BaseDestination.swift
@@ -165,6 +165,15 @@ public class BaseDestination: Hashable, Equatable {
         }
         return false
     }
+
+  /**
+    Triggered by main flush() method on each destination. Runs in background thread.
+   Use for destinations that buffer log items, implement this function to flush those
+   buffers to their final destination (web server...)
+   */
+  func flush() {
+    // no implementation in base destination needed
+  }
 }
 
 public func == (lhs: BaseDestination, rhs: BaseDestination) -> Bool {

--- a/sources/SwiftyBeaver.swift
+++ b/sources/SwiftyBeaver.swift
@@ -125,6 +125,7 @@ public class SwiftyBeaver {
       if let queue = dest.queue {
         dispatch_group_enter(grp)
         dispatch_async(queue, {
+          dest.flush()
           dispatch_group_leave(grp)
         })
       }


### PR DESCRIPTION
Thought those of you working on log destination to remote systems (Loggly #67 ...) would find this useful. Creates a flush method on the destination that gets called as part of the main flush process. So if you are buffering in the destination this hook gives you a place to flush/send those log items to the remote server before the system shuts down.