### PR TITLE
forcing the ConsoleDestination to use the main queue

### DIFF
--- a/sources/BaseDestination.swift
+++ b/sources/BaseDestination.swift
@@ -78,7 +78,7 @@ public class BaseDestination: Hashable, Equatable {
 
     // each destination instance must have an own serial queue to ensure serial output
     // GCD gives it a prioritization between User Initiated and Utility
-    var queue: dispatch_queue_t?
+    internal var queue: dispatch_queue_t?
 
     public init() {
         let uuid = NSUUID().UUIDString

--- a/sources/BaseDestination.swift
+++ b/sources/BaseDestination.swift
@@ -78,13 +78,18 @@ public class BaseDestination: Hashable, Equatable {
 
     // each destination instance must have an own serial queue to ensure serial output
     // GCD gives it a prioritization between User Initiated and Utility
-    internal var queue: dispatch_queue_t?
+    var queue: dispatch_queue_t?
 
     public init() {
         let uuid = NSUUID().UUIDString
         let queueLabel = "swiftybeaver-queue-" + uuid
         queue = dispatch_queue_create(queueLabel, nil)
     }
+    
+    public init(queue q:dispatch_queue_t) {
+        queue = q
+    }
+    
 
     /// overrule the destination’s minLevel for a given path and optional function
     public func addMinLevelFilter(minLevel: SwiftyBeaver.Level, path: String, function: String = "") {

--- a/sources/ConsoleDestination.swift
+++ b/sources/ConsoleDestination.swift
@@ -15,6 +15,7 @@ public class ConsoleDestination: BaseDestination {
 
     public override init() {
         super.init()
+        self.queue = dispatch_get_main_queue() // print wants to be done in the mainq
     }
 
     // print to Xcode Console. uses full base class functionality

--- a/sources/ConsoleDestination.swift
+++ b/sources/ConsoleDestination.swift
@@ -14,8 +14,7 @@ public class ConsoleDestination: BaseDestination {
     override public var defaultHashValue: Int {return 1}
 
     public override init() {
-        super.init()
-        self.queue = dispatch_get_main_queue() // print wants to be done in the mainq
+        super.init(queue: dispatch_get_main_queue())
     }
 
     // print to Xcode Console. uses full base class functionality


### PR DESCRIPTION
 to avoid print() issues..

About half the time I am seeing ZERO output in my debugger for stuff going to the console.

I think there are issues with using Swift 'print' outside of the mainq.

This change just forces the ConsoleDestionation to use the mainq as it's queue.   
This seems to have gotten rid of my 'where are my console logs' problem.

 Also allows people to define their own custom queues for their own Destinations. 

