### PR TITLE
Allow empty log messages.

### DIFF
--- a/sources/SwiftyBeaver.swift
+++ b/sources/SwiftyBeaver.swift
@@ -114,15 +114,13 @@ public class SwiftyBeaver {
                 // try to convert msg object to String and put it on queue
                 let msgStr = "\(message())"
 
-                if !msgStr.isEmpty {
-                    if dest.asynchronously {
-                        dispatch_async(queue) {
-                            dest.send(level, msg: msgStr, thread: thread, path: path, function: function, line: line)
-                        }
-                    } else {
-                        dispatch_sync(queue) {
-                            dest.send(level, msg: msgStr, thread: thread, path: path, function: function, line: line)
-                        }
+                if dest.asynchronously {
+                    dispatch_async(queue) {
+                        dest.send(level, msg: msgStr, thread: thread, path: path, function: function, line: line)
+                    }
+                } else {
+                    dispatch_sync(queue) {
+                        dest.send(level, msg: msgStr, thread: thread, path: path, function: function, line: line)
                     }
                 }
             }


### PR DESCRIPTION
These were deliberately being thrown away, but for no apparent reason.

The log message will eventually contain useful information, like the
source location, time, and thread, and so there's value in having a log
message emitted even if the "message" is empty.

This means that client code can do log.debug("") and still see when that
line is reached, or log.error("\(serverError)") and still see that
something bad happened, even if the server returned nothing.