### PR TITLE
Expose destinations property (read-only)

### DIFF
--- a/SwiftyBeaver.xcodeproj/project.pbxproj
+++ b/SwiftyBeaver.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		048E6BFA1CDBB68E00DC9116 /* DestinationSetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048E6BF91CDBB68E00DC9116 /* DestinationSetTests.swift */; };
 		9E195B0A1C6B3B4600D924CB /* AES256CBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E195B091C6B3B4600D924CB /* AES256CBC.swift */; };
 		9E195B0B1C6B3B4600D924CB /* AES256CBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E195B091C6B3B4600D924CB /* AES256CBC.swift */; };
 		9E195B0C1C6B3B4600D924CB /* AES256CBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E195B091C6B3B4600D924CB /* AES256CBC.swift */; };
@@ -58,6 +59,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		048E6BF91CDBB68E00DC9116 /* DestinationSetTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DestinationSetTests.swift; sourceTree = "<group>"; };
 		9E195B091C6B3B4600D924CB /* AES256CBC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AES256CBC.swift; path = sources/AES256CBC.swift; sourceTree = "<group>"; };
 		9E195B0E1C6B3B6F00D924CB /* AES256CBCTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AES256CBCTests.swift; sourceTree = "<group>"; };
 		9E195B101C6B766D00D924CB /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -174,6 +176,7 @@
 				9EDCE3F31C09D211002FA4A7 /* SwiftyBeaverTests.swift */,
 				9EA53F881C561E4C00B160AF /* Secrets.swift */,
 				9EA53F8A1C561EE600B160AF /* SecretsExample.swift */,
+				048E6BF91CDBB68E00DC9116 /* DestinationSetTests.swift */,
 			);
 			path = SwiftyBeaverTests;
 			sourceTree = "<group>";
@@ -425,6 +428,7 @@
 				9EA53F8B1C561EE600B160AF /* SecretsExample.swift in Sources */,
 				9ED096FD1C521D3200FE3059 /* SBPlatformDestinationTests.swift in Sources */,
 				9EDCE3F41C09D211002FA4A7 /* SwiftyBeaverTests.swift in Sources */,
+				048E6BFA1CDBB68E00DC9116 /* DestinationSetTests.swift in Sources */,
 				9E195B0F1C6B3B6F00D924CB /* AES256CBCTests.swift in Sources */,
 				9E6CA9FC1C12BA7A009D9093 /* BaseDestinationTests.swift in Sources */,
 			);

--- a/SwiftyBeaverTests/DestinationSetTests.swift
+++ b/SwiftyBeaverTests/DestinationSetTests.swift
@@ -1,0 +1,80 @@
+//
+//  DestinationSetTests.swift
+//  SwiftyBeaver
+//
+//  Created by Mark Schultz on 5/5/16.
+//  Copyright © 2016 Sebastian Kreutzberger. All rights reserved.
+//
+
+import XCTest
+import SwiftyBeaver
+
+class DestinationSetTests: XCTestCase {
+    
+    override func tearDown() {
+        super.tearDown()
+        SwiftyBeaver.removeAllDestinations()
+    }
+    
+    func testChangeDestinationsMinLogLevels() {
+        let log = SwiftyBeaver.self
+        
+        // Test for default state
+        XCTAssertEqual(log.countDestinations(), 0)
+        
+        // add valid destinations
+        let console = ConsoleDestination()
+        let console2 = ConsoleDestination()
+        let file = FileDestination()
+        
+        log.addDestination(console)
+        log.addDestination(console2)
+        log.addDestination(file)
+        
+        // Test that destinations are successfully added
+        XCTAssertEqual(log.countDestinations(), 3)
+        
+        // Test default log level of destinations
+        log.destinations.forEach {
+            XCTAssertEqual($0.minLevel, SwiftyBeaver.Level.Verbose)
+        }
+        
+        // Change min log level for all destinations
+        log.destinations.forEach { $0.minLevel = .Info }
+        
+        // Test min level of destinations has changed
+        log.destinations.forEach {
+            XCTAssertEqual($0.minLevel, SwiftyBeaver.Level.Info)
+        }
+    }
+    
+    func testRemoveConsoleDestinations() {
+        let log = SwiftyBeaver.self
+        
+        // Test for default state
+        XCTAssertEqual(log.countDestinations(), 0)
+        
+        // add valid destinations
+        let console = ConsoleDestination()
+        let console2 = ConsoleDestination()
+        let file = FileDestination()
+        
+        log.addDestination(console)
+        log.addDestination(console2)
+        log.addDestination(file)
+        
+        // Test that destinations are successfully added
+        XCTAssertEqual(log.countDestinations(), 3)
+        
+        // Remove console destinations
+        log.destinations.forEach {
+            if let consoleDestination = $0 as? ConsoleDestination {
+                log.removeDestination(consoleDestination)
+            }
+        }
+        
+        // Test that console destinations are removed
+        XCTAssertEqual(log.countDestinations(), 1)
+    }
+    
+}

--- a/sources/SwiftyBeaver.swift
+++ b/sources/SwiftyBeaver.swift
@@ -25,7 +25,7 @@ public class SwiftyBeaver {
     }
 
     // a set of active destinations
-    static var destinations = Set<BaseDestination>()
+    public private(set) static var destinations = Set<BaseDestination>()
 
     // MARK: Destination Handling
 


### PR DESCRIPTION
Make the `destinations` property `public private(set)`. This allows consumers of `SwiftyBeaver` to iterate through the `destinations` to make changes, rather than having to store their own collection of destinations.