### PR TITLE
Add optional message filter to BaseDestination

### DIFF
--- a/SwiftyBeaverTests/BaseDestinationTests.swift
+++ b/SwiftyBeaverTests/BaseDestinationTests.swift
@@ -150,4 +150,101 @@ class BaseDestinationTests: XCTestCase {
         // check filter 5 (function)
         XCTAssertTrue(obj.shouldLevelBeLogged(SwiftyBeaver.Level.Verbose, path: "", function: "MyFunction"))
     }
+
+    func test_shouldMessageBeLogged_noMessageFilters_answersTrue() {
+        let obj = BaseDestination()
+        obj.minLevel = SwiftyBeaver.Level.Info
+
+        obj.addMinLevelFilter(.Info, path: "", function: "", messageFilter: nil)
+
+        XCTAssertTrue(obj.shouldMessageBeLogged("Hello"))
+    }
+
+    func test_shouldMessageBeLogged_oneLevelFilterWithMessageFilterThatAnswersTrue_answersTrue() {
+        let obj = BaseDestination()
+        obj.minLevel = SwiftyBeaver.Level.Info
+
+        obj.addMinLevelFilter(.Info, path: "", function: "") {
+            message in
+
+            return true
+        }
+
+
+        XCTAssertTrue(obj.shouldMessageBeLogged("Hello"))
+    }
+
+    func test_shouldMessageBeLogged_oneLevelFilterWithMessageFilterThatAnswersFalse_answersFalse() {
+        let obj = BaseDestination()
+        obj.minLevel = SwiftyBeaver.Level.Info
+
+        obj.addMinLevelFilter(.Info, path: "", function: "") {
+            message in
+
+            return false
+        }
+
+
+        XCTAssertFalse(obj.shouldMessageBeLogged("Hello"))
+    }
+
+    func test_shouldMessageBeLogged_multipleLevelFiltersWithMessageFiltersThatAnswersTrue_answersTrue() {
+        let obj = BaseDestination()
+        obj.minLevel = SwiftyBeaver.Level.Info
+
+        obj.addMinLevelFilter(.Info, path: "", function: "") {
+            message in
+
+            return true
+        }
+
+        obj.addMinLevelFilter(.Info, path: "", function: "") {
+            message in
+
+            return 1 + 1 == 2
+        }
+
+
+        XCTAssertTrue(obj.shouldMessageBeLogged("Hello"))
+    }
+
+    func test_shouldMessageBeLogged_multipleLevelFiltersWithMessageFiltersAnswersFalse_answersFalse() {
+        let obj = BaseDestination()
+        obj.minLevel = SwiftyBeaver.Level.Info
+
+        obj.addMinLevelFilter(.Info, path: "", function: "") {
+            message in
+
+            return false
+        }
+
+        obj.addMinLevelFilter(.Info, path: "", function: "") {
+            message in
+
+            return 1 + 1 == 3
+        }
+
+
+        XCTAssertFalse(obj.shouldMessageBeLogged("Hello"))
+    }
+
+    func test_shouldMessageBeLogged_multipleLevelFiltersWithMessageFiltersOneAnswersTrueOneAnswersFalse_answersFalse() {
+        let obj = BaseDestination()
+        obj.minLevel = SwiftyBeaver.Level.Info
+
+        obj.addMinLevelFilter(.Info, path: "", function: "") {
+            message in
+
+            return true
+        }
+
+        obj.addMinLevelFilter(.Info, path: "", function: "") {
+            message in
+
+            return 1 + 1 == 3
+        }
+
+
+        XCTAssertFalse(obj.shouldMessageBeLogged("Hello"))
+    }
 }

--- a/sources/BaseDestination.swift
+++ b/sources/BaseDestination.swift
@@ -28,6 +28,7 @@ struct MinLevelFilter {
     var minLevel = SwiftyBeaver.Level.Verbose
     var path = ""
     var function = ""
+    var messageFilter : (String -> Bool)?
 }
 
 /// destination which all others inherit from. do not directly use
@@ -89,8 +90,8 @@ public class BaseDestination: Hashable, Equatable {
     }
 
     /// overrule the destination’s minLevel for a given path and optional function
-    public func addMinLevelFilter(minLevel: SwiftyBeaver.Level, path: String, function: String = "") {
-        let filter = MinLevelFilter(minLevel: minLevel, path: path, function: function)
+    public func addMinLevelFilter(minLevel: SwiftyBeaver.Level, path: String, function: String = "", messageFilter: (String -> Bool)? = nil) {
+        let filter = MinLevelFilter(minLevel: minLevel, path: path, function: function, messageFilter: messageFilter)
         minLevelFilters.append(filter)
     }
 
@@ -224,6 +225,20 @@ public class BaseDestination: Hashable, Equatable {
             }
         }
         return false
+    }
+
+    /// checks if the message should be logged using the message filter, if one is specified
+    /// returns boolean and can be used to decide if a message should be logged or not
+    func shouldMessageBeLogged(message: String) -> Bool {
+        return minLevelFilters.filter() {
+            minLevelFilter in
+
+            guard let messageFilter = minLevelFilter.messageFilter else {
+                return true
+            }
+
+            return messageFilter(message)
+        }.count == minLevelFilters.count // All minLevelFilters must agree
     }
 
   /**


### PR DESCRIPTION
It might be desirable to further filter messages based upon the message content itself.
Since filtering by message content first requires that the message be resolved to a String, thereby
defeating the purpose of the @autoclosure, the minLevelFilters are first applied. If the message is
not filtered by the level filtering using level, path and function, then the message is resolved
(once instead of once for each destination) and if there are any message filters in place, those
are invoked to see if any message filters reject the message.

This change provides additional flexibility for content-based filtering where level, path and function filtering
is not enough.

Resolving the message once for each destination introduces the remote possibility of a bug. If the expression
changes each time it is run, the message could be different for each destination. This change resolves the message
once and only once per log request regardless of how many destinations there are.

Only if the message gets through all message filters is it sent to the destination.

Additional tests have been written to verify.