### PR TITLE
Add Swift 3 swift-DEVELOPMENT-SNAPSHOT-2016-05-09 compatibility.

### DIFF
--- a/SwiftyBeaverTests/AES256CBCTests.swift
+++ b/SwiftyBeaverTests/AES256CBCTests.swift
@@ -112,8 +112,13 @@ class AES256CBCTests: XCTestCase {
         XCTAssertEqual(text.characters.count, length)
         XCTAssertEqual(text2.characters.count, length)
         XCTAssertNotEqual(text, text2)
+        #if swift(>=3.0)
+        XCTAssertNil(text.range(of: " "))
+        XCTAssertNil(text2.range(of: " "))
+        #else
         XCTAssertNil(text.rangeOfString(" "))
         XCTAssertNil(text2.rangeOfString(" "))
+        #endif
     }
 
     func testGeneratePassword() {
@@ -122,8 +127,14 @@ class AES256CBCTests: XCTestCase {
         XCTAssertEqual(pw.characters.count, 32)
         XCTAssertEqual(pw2.characters.count, 32)
         XCTAssertNotEqual(pw, pw2)
+        #if swift(>=3.0)
+        XCTAssertNil(pw.range(of: " "))
+        XCTAssertNil(pw2.range(of: " "))
+        #else
         XCTAssertNil(pw.rangeOfString(" "))
         XCTAssertNil(pw2.rangeOfString(" "))
+        #endif
+
     }
 
 }

--- a/SwiftyBeaverTests/BaseDestinationTests.swift
+++ b/SwiftyBeaverTests/BaseDestinationTests.swift
@@ -35,7 +35,11 @@ class BaseDestinationTests: XCTestCase {
         // HH:mm:ss
         let formatter = NSDateFormatter()
         formatter.dateFormat = "HH:mm:ss"
+        #if swift(>=3.0)
+        let dateStr = formatter.string(from: NSDate())
+        #else
         let dateStr = formatter.stringFromDate(NSDate())
+        #endif
         str = BaseDestination().formattedDate(formatter.dateFormat)
         XCTAssertEqual(str, dateStr)
     }
@@ -79,23 +83,44 @@ class BaseDestinationTests: XCTestCase {
         var str = ""
         let formatter = NSDateFormatter()
         formatter.dateFormat = "HH:mm:ss"
-        let dateStr = formatter.stringFromDate(NSDate())
+        
+        #if swift(>=3.0)
+        let dateStr = formatter.string(from: NSDate())
 
         // logging to main thread does not output thread name
         str = obj.formattedMessage(dateStr, levelString: "DEBUG", msg: "Hello", thread: "main",
             path: "/path/to/ViewController.swift", function: "testFunction()", line: 50, detailOutput: false)
-        XCTAssertNotNil(str.rangeOfString("[\(dateStr)] DEBUG: Hello"))
-        XCTAssertNil(str.rangeOfString("main"))
-        XCTAssertNil(str.rangeOfString("|"))
+        XCTAssertNotNil(str.range(of: "[\(dateStr)] DEBUG: Hello"))
+        XCTAssertNil(str.range(of: "main"))
+        XCTAssertNil(str.range(of: "|"))
 
         str = obj.formattedMessage(dateStr, levelString: "DEBUG", msg: "Hello", thread: "myThread",
             path: "/path/to/ViewController.swift", function: "testFunction()", line: 50, detailOutput: true)
-        XCTAssertNotNil(str.rangeOfString("[\(dateStr)] |myThread| ViewController.testFunction():50 DEBUG: Hello"))
+        XCTAssertNotNil(str.range(of: "[\(dateStr)] |myThread| ViewController.testFunction():50 DEBUG: Hello"))
 
         str = obj.formattedMessage(dateStr, levelString: "DEBUG", msg: "Hello", thread: "",
             path: "/path/to/ViewController.swift", function: "testFunction()", line: 50, detailOutput: true)
+        XCTAssertNotNil(str.range(of: "[\(dateStr)] ViewController.testFunction():50 DEBUG: Hello"))
+        XCTAssertNil(str.range(of: "|"))
+        #else
+        let dateStr = formatter.stringFromDate(NSDate())
+        
+        // logging to main thread does not output thread name
+        str = obj.formattedMessage(dateStr, levelString: "DEBUG", msg: "Hello", thread: "main",
+        path: "/path/to/ViewController.swift", function: "testFunction()", line: 50, detailOutput: false)
+        XCTAssertNotNil(str.rangeOfString("[\(dateStr)] DEBUG: Hello"))
+        XCTAssertNil(str.rangeOfString("main"))
+        XCTAssertNil(str.rangeOfString("|"))
+        
+        str = obj.formattedMessage(dateStr, levelString: "DEBUG", msg: "Hello", thread: "myThread",
+        path: "/path/to/ViewController.swift", function: "testFunction()", line: 50, detailOutput: true)
+        XCTAssertNotNil(str.rangeOfString("[\(dateStr)] |myThread| ViewController.testFunction():50 DEBUG: Hello"))
+        
+        str = obj.formattedMessage(dateStr, levelString: "DEBUG", msg: "Hello", thread: "",
+        path: "/path/to/ViewController.swift", function: "testFunction()", line: 50, detailOutput: true)
         XCTAssertNotNil(str.rangeOfString("[\(dateStr)] ViewController.testFunction():50 DEBUG: Hello"))
         XCTAssertNil(str.rangeOfString("|"))
+        #endif
     }
 
     func testFormattedMessageEmptyDate() {

--- a/SwiftyBeaverTests/SBPlatformDestinationTests.swift
+++ b/SwiftyBeaverTests/SBPlatformDestinationTests.swift
@@ -73,6 +73,15 @@ class SBPlatformDestinationTests: XCTestCase {
         if let str = str {
             XCTAssertEqual(str.characters.first, "{")
             XCTAssertEqual(str.characters.last, "}")
+            #if swift(>=3.0)
+            XCTAssertNotNil(str.range(of: "\"line\":123"))
+            XCTAssertNotNil(str.range(of: "\"message\":\"test message\\nNewlineäößø\""))
+            XCTAssertNotNil(str.range(of: "\"fileName\":\"path.swift\""))
+            XCTAssertNotNil(str.range(of: "\"timestamp\":"))
+            XCTAssertNotNil(str.range(of: "\"level\":0"))
+            XCTAssertNotNil(str.range(of: "\"thread\":\"\""))
+            XCTAssertNotNil(str.range(of: "\"function\":\"TestFunction()\""))
+            #else
             XCTAssertNotNil(str.rangeOfString("\"line\":123"))
             XCTAssertNotNil(str.rangeOfString("\"message\":\"test message\\nNewlineäößø\""))
             XCTAssertNotNil(str.rangeOfString("\"fileName\":\"path.swift\""))
@@ -80,6 +89,7 @@ class SBPlatformDestinationTests: XCTestCase {
             XCTAssertNotNil(str.rangeOfString("\"level\":0"))
             XCTAssertNotNil(str.rangeOfString("\"thread\":\"\""))
             XCTAssertNotNil(str.rangeOfString("\"function\":\"TestFunction()\""))
+            #endif
         }
     }
 
@@ -111,7 +121,12 @@ class SBPlatformDestinationTests: XCTestCase {
 
         // invalid address
         platform.serverURL = NSURL(string: "https://notexisting.swiftybeaver.com")!
+        #if swift(>=3.0)
+        let exp = expectation(withDescription: "returns false due to invalid URL")
+        #else
         let exp = expectationWithDescription("returns false due to invalid URL")
+        #endif
+
 
         platform.sendToServerAsync(jsonStr) {
             ok, status in
@@ -123,7 +138,12 @@ class SBPlatformDestinationTests: XCTestCase {
         // invalid app ID
         platform.serverURL = correctURL
         platform.appID = "abc"
+        #if swift(>=3.0)
+        let exp2 = expectation(withDescription: "returns false due to invalid app ID")
+        #else
         let exp2 = expectationWithDescription("returns false due to invalid app ID")
+        #endif
+
 
         platform.sendToServerAsync(jsonStr) {
             ok, status in
@@ -135,7 +155,11 @@ class SBPlatformDestinationTests: XCTestCase {
         // invalid secret
         platform.appID = Secrets.Platform.appID
         platform.appSecret += "invalid"
+        #if swift(>=3.0)
+        let exp3 = expectation(withDescription: "returns false due to invalid secret")
+        #else
         let exp3 = expectationWithDescription("returns false due to invalid secret")
+        #endif
 
         platform.sendToServerAsync(jsonStr) {
             ok, status in
@@ -158,7 +182,13 @@ class SBPlatformDestinationTests: XCTestCase {
             exp4.fulfill()
         }
         */
+        #if swift(>=3.0)
+        waitForExpectations(withTimeout: 5, handler: nil)
+        #else
         waitForExpectationsWithTimeout(5, handler: nil)
+        #endif
+
+
     }
 
     func testIntegration() {
@@ -193,10 +223,16 @@ class SBPlatformDestinationTests: XCTestCase {
             }
 
             formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+            #if swift(>=3.0)
+            let dateStr = formatter.string(from: NSDate())
+            #else
             let dateStr = formatter.stringFromDate(NSDate())
+            #endif
+
             log.debug("msg \(index) - \(dateStr)")
         }
         log.flush(3)
+
         // do some further waiting for sending to complete
         for _ in 1...platform.sendingPoints.Threshold + 3 {
             // simulate work by doing a computing
@@ -243,6 +279,7 @@ class SBPlatformDestinationTests: XCTestCase {
         if let userName = dict["userName"] as? String {
             XCTAssertEqual(userName, "")
         }
+
         XCTAssertTrue(platform.saveDictToFile(dict, url: platform.analyticsFileURL))
 
         // set userName
@@ -259,7 +296,11 @@ class SBPlatformDestinationTests: XCTestCase {
     /// helper function to delete temp file before test
     func deleteFile(url: NSURL) -> Bool {
         do {
+            #if swift(>=3.0)
+            try NSFileManager.default().removeItem(at: url)
+            #else
             try NSFileManager.defaultManager().removeItemAtURL(url)
+            #endif
             return true
         } catch let error {
             NSLog("Unit test: could not delete file \(url). \(error)")

--- a/sources/AES256CBC.swift
+++ b/sources/AES256CBC.swift
@@ -19,7 +19,8 @@ final class AES256CBC {
     /// returns optional encrypted string via AES-256CBC
     /// automatically generates and puts a random IV at first 16 chars
     /// the password must be exactly 32 chars long for AES-256
-    class func encryptString(str: String, password: String) -> String? {
+    #if swift(>=3.0)
+    class func encryptString(_ str: String, password: String) -> String? {
         if !str.isEmpty && password.characters.count == 32 {
             let iv = randomText(16)
             let key = password
@@ -34,17 +35,35 @@ final class AES256CBC {
         }
         return nil
     }
+    #else
+    class func encryptString(str: String, password: String) -> String? {
+        if !str.isEmpty && password.characters.count == 32 {
+            let iv = randomText(16)
+            let key = password
+            
+            do {
+                let encryptedString = try aesEncrypt(str, key: key, iv: iv)
+                let ret = iv + encryptedString
+                return ret
+            } catch let err as NSError {
+                NSLog(err.localizedDescription)
+            }
+        }
+        return nil
+    }
+    #endif
 
     /// returns optional decrypted string via AES-256CBC
     /// IV need to be at first 16 chars, password must be 32 chars long
-    class func decryptString(str: String, password: String) -> String? {
+    #if swift(>=3.0)
+    class func decryptString(_ str: String, password: String) -> String? {
         if str.characters.count > 16 && password.characters.count == 32 {
             // get AES initialization vector from first 16 chars
-            let ivRange = str.startIndex..<str.startIndex.advancedBy(16)
-            let iv = str.substringWithRange(ivRange)
-            let encryptedString = str.stringByReplacingOccurrencesOfString(iv, withString: "",
-                options: NSStringCompareOptions.LiteralSearch, range: nil) // remove IV
-
+            let ivRange = str.startIndex..<str.index(str.startIndex, offsetBy: 16)
+            let iv = str.substring(with: ivRange)
+            let encryptedString = str.replacingOccurrences(of: iv, with: "",
+                options: NSStringCompareOptions.literalSearch, range: nil) // remove IV
+            
             do {
                 let decryptedString = try aesDecrypt(encryptedString, key: password, iv: iv)
                 return decryptedString
@@ -54,30 +73,76 @@ final class AES256CBC {
         }
         return nil
     }
+    #else
+    class func decryptString(str: String, password: String) -> String? {
+        if str.characters.count > 16 && password.characters.count == 32 {
+            // get AES initialization vector from first 16 chars
+            let ivRange = str.startIndex..<str.startIndex.advancedBy(16)
+            let iv = str.substringWithRange(ivRange)
+            let encryptedString = str.stringByReplacingOccurrencesOfString(iv, withString: "",
+            options: NSStringCompareOptions.LiteralSearch, range: nil) // remove IV
+    
+            do {
+                let decryptedString = try aesDecrypt(encryptedString, key: password, iv: iv)
+                return decryptedString
+            } catch let err as NSError {
+                NSLog(err.localizedDescription)
+            }
+        }
+        return nil
+    }
+    #endif
+
 
     /// returns encrypted string, IV must be 16 chars long
+    #if swift(>=3.0)
+    private class func aesEncrypt(_ str: String, key: String, iv: String) throws -> String {
+        let keyData = key.data(using: NSUTF8StringEncoding)!
+        let ivData = iv.data(using: NSUTF8StringEncoding)!
+        let data = str.data(using: NSUTF8StringEncoding)!
+        let enc = try NSData.withBytes(bytes: AESCipher(key: keyData.arrayOfBytes(),
+            iv: ivData.arrayOfBytes()).encrypt(bytes: data.arrayOfBytes()))
+        let base64String: String = enc.base64EncodedString(NSDataBase64EncodingOptions(rawValue: 0))
+        let result = String(base64String)
+        return result
+    }
+    #else
     private class func aesEncrypt(str: String, key: String, iv: String) throws -> String {
         let keyData = key.dataUsingEncoding(NSUTF8StringEncoding)!
         let ivData = iv.dataUsingEncoding(NSUTF8StringEncoding)!
         let data = str.dataUsingEncoding(NSUTF8StringEncoding)!
-
         let enc = try NSData.withBytes(AESCipher(key: keyData.arrayOfBytes(),
-            iv: ivData.arrayOfBytes()).encrypt(data.arrayOfBytes()))
+        iv: ivData.arrayOfBytes()).encrypt(data.arrayOfBytes()))
         let base64String: String = enc.base64EncodedStringWithOptions(NSDataBase64EncodingOptions(rawValue: 0))
         let result = String(base64String)
         return result
     }
+    #endif
 
     /// returns decrypted string, IV must be 16 chars long
+    #if swift(>=3.0)
+    private class func aesDecrypt(_ str: String, key: String, iv: String) throws -> String {
+        let keyData = key.data(using: NSUTF8StringEncoding)!
+        let ivData = iv.data(using: NSUTF8StringEncoding)!
+        let data = NSData(base64Encoded: str, options: NSDataBase64DecodingOptions(rawValue: 0))!
+        let dec = try NSData.withBytes(bytes: AESCipher(key: keyData.arrayOfBytes(),
+            iv: ivData.arrayOfBytes()).decrypt(bytes: data.arrayOfBytes()))
+        let result = NSString(data: dec, encoding: NSUTF8StringEncoding)
+        return String(result!)
+    }
+    #else
     private class func aesDecrypt(str: String, key: String, iv: String) throws -> String {
         let keyData = key.dataUsingEncoding(NSUTF8StringEncoding)!
         let ivData = iv.dataUsingEncoding(NSUTF8StringEncoding)!
         let data = NSData(base64EncodedString: str, options: NSDataBase64DecodingOptions(rawValue: 0))!
         let dec = try NSData.withBytes(AESCipher(key: keyData.arrayOfBytes(),
-            iv: ivData.arrayOfBytes()).decrypt(data.arrayOfBytes()))
+        iv: ivData.arrayOfBytes()).decrypt(data.arrayOfBytes()))
         let result = NSString(data: dec, encoding: NSUTF8StringEncoding)
         return String(result!)
     }
+    #endif
+
+
 
     /// returns random string (uppercase & lowercase, no spaces) of 32 characters length
     /// which can be used as SHA-256 compatbile password
@@ -88,6 +153,44 @@ final class AES256CBC {
     /// returns random text of a defined length.
     /// Optional bool parameter justLowerCase to just generate random lowercase text and
     /// whitespace to exclude the whitespace character
+    #if swift(>=3.0)
+    class func randomText(_ length: Int, justLowerCase: Bool = false, whitespace: Bool = false) -> String {
+        var text = ""
+        for _ in 1...length {
+            var decValue = 0  // ascii decimal value of a character
+            var charType = 3  // default is lowercase
+            if justLowerCase == false {
+                // randomize the character type
+                charType =  Int(arc4random_uniform(4))
+            }
+            switch charType {
+            case 1:  // digit: random Int between 48 and 57
+                decValue = Int(arc4random_uniform(10)) + 48
+            case 2:  // uppercase letter
+                decValue = Int(arc4random_uniform(26)) + 65
+            case 3:  // lowercase letter
+                decValue = Int(arc4random_uniform(26)) + 97
+            default:  // space character
+                if whitespace {
+                    decValue = 32
+                } else {
+                    // upper case letter
+                    decValue = Int(arc4random_uniform(26)) + 65
+                }
+            }
+            // get ASCII character from random decimal value
+            let char = String(UnicodeScalar(decValue))
+            text = text + char
+            // remove double spaces if existing
+            #if swift(>=3.0)
+            text = text.replacingOccurrences(of: "  ", with: " ")
+            #else
+            text = text.stringByReplacingOccurrencesOfString("  ", withString: " ")
+            #endif
+        }
+        return text
+    }
+    #else
     class func randomText(length: Int, justLowerCase: Bool = false, whitespace: Bool = false) -> String {
         var text = ""
         for _ in 1...length {
@@ -116,10 +219,17 @@ final class AES256CBC {
             let char = String(UnicodeScalar(decValue))
             text = text + char
             // remove double spaces if existing
-            text = text.stringByReplacingOccurrencesOfString("  ", withString: " ")
+            #if swift(>=3.0)
+                text = text.replacingOccurrences(of: "  ", with: " ")
+            #else
+                text = text.stringByReplacingOccurrencesOfString("  ", withString: " ")
+            #endif
         }
         return text
     }
+    #endif
+
+
 
 }
 
@@ -149,11 +259,19 @@ final class AES256CBC {
 
 final private class AESCipher {
 
+    #if swift(>=3.0)
+    enum Error: ErrorProtocol {
+        case BlockSizeExceeded
+        case InvalidKeyOrInitializationVector
+        case InvalidInitializationVector
+    }
+    #else
     enum Error: ErrorType {
         case BlockSizeExceeded
         case InvalidKeyOrInitializationVector
         case InvalidInitializationVector
     }
+    #endif
 
     enum AESVariant: Int {
         case AES128 = 1, AES192, AES256
@@ -188,8 +306,13 @@ final private class AESCipher {
     private let key: [UInt8]
     private let iv: [UInt8]?
     private let blockMode = CBCBlockMode()
+    #if swift(>=3.0)
+    private lazy var expandedKey: [[UInt32]] = self.expandKey(key: self.key, variant: self.variant)
+    private lazy var expandedKeyInv: [[UInt32]] = self.expandKeyInv(key: self.key, variant: self.variant)
+    #else
     private lazy var expandedKey: [[UInt32]] = self.expandKey(self.key, variant: self.variant)
     private lazy var expandedKeyInv: [[UInt32]] = self.expandKeyInv(self.key, variant: self.variant)
+    #endif
 
     private lazy var sBoxes:(sBox: [UInt32], invSBox: [UInt32]) = self.calculateSBox()
     private lazy var sBox: [UInt32] = self.sBoxes.sBox
@@ -629,7 +752,11 @@ final private class AESCipher {
 
     convenience init(key: [UInt8]) throws {
         // default IV is all 0x00...
+        #if swift(>=3.0)
+        let defaultIV = [UInt8](repeating: 0, count: AESCipher.blockSize)
+        #else
         let defaultIV = [UInt8](count: AESCipher.blockSize, repeatedValue: 0)
+        #endif
         try self.init(key: key, iv: defaultIV)
     }
 
@@ -643,17 +770,27 @@ final private class AESCipher {
      */
 
     func encrypt(bytes: [UInt8]) throws -> [UInt8] {
+        #if swift(>=3.0)
+        let finalBytes = PKCS7().add(bytes: bytes, blockSize: AESCipher.blockSize)
+        let blocks = finalBytes.chunks(chunksize: AESCipher.blockSize)
+        return try blockMode.encryptBlocks(blocks: blocks, iv: self.iv, cipherOperation: encryptBlock)
+        #else
         let finalBytes = PKCS7().add(bytes, blockSize: AESCipher.blockSize)
         let blocks = finalBytes.chunks(AESCipher.blockSize)
         return try blockMode.encryptBlocks(blocks, iv: self.iv, cipherOperation: encryptBlock)
+        #endif
     }
 
     private func encryptBlock(block: [UInt8]) -> [UInt8]? {
         let rounds = self.variant.Nr
         let rk = self.expandedKey
+        #if swift(>=3.0)
+        var b = toUInt32Array(slice: block[block.startIndex..<block.endIndex])
+        var t = [UInt32](repeating: 0, count: 4)
+        #else
         var b = toUInt32Array(block[block.startIndex..<block.endIndex])
-
         var t = [UInt32](count: 4, repeatedValue: 0)
+        #endif
 
         for r in 0..<rounds - 1 {
             t[0] = b[0] ^ rk[r][0]
@@ -695,10 +832,17 @@ final private class AESCipher {
         t[3] = b[3] ^ rk[r][3]
 
         // rounds
+        #if swift(>=3.0)
+        b[0] = F1(x0: t[0], t[1], t[2], t[3]) ^ rk[rounds][0]
+        b[1] = F1(x0: t[1], t[2], t[3], t[0]) ^ rk[rounds][1]
+        b[2] = F1(x0: t[2], t[3], t[0], t[1]) ^ rk[rounds][2]
+        b[3] = F1(x0: t[3], t[0], t[1], t[2]) ^ rk[rounds][3]
+        #else
         b[0] = F1(t[0], t[1], t[2], t[3]) ^ rk[rounds][0]
         b[1] = F1(t[1], t[2], t[3], t[0]) ^ rk[rounds][1]
         b[2] = F1(t[2], t[3], t[0], t[1]) ^ rk[rounds][2]
         b[3] = F1(t[3], t[0], t[1], t[2]) ^ rk[rounds][3]
+        #endif
 
         var out = [UInt8]()
         out.reserveCapacity(b.count * 4)
@@ -717,19 +861,35 @@ final private class AESCipher {
             throw Error.BlockSizeExceeded
         }
 
+        #if swift(>=3.0)
+        let blocks = bytes.chunks(chunksize: AESCipher.blockSize)
+        return try PKCS7().remove(bytes: blockMode.decryptBlocks(blocks: blocks,
+            iv: self.iv, cipherOperation: decryptBlock), blockSize: AESCipher.blockSize)
+        #else
         let blocks = bytes.chunks(AESCipher.blockSize)
         return try PKCS7().remove(blockMode.decryptBlocks(blocks,
             iv: self.iv, cipherOperation: decryptBlock), blockSize: AESCipher.blockSize)
+        #endif
+
     }
 
     private func decryptBlock(block: [UInt8]) -> [UInt8]? {
         let rounds = self.variant.Nr
         let rk = expandedKeyInv
+        #if swift(>=3.0)
+        var b = toUInt32Array(slice: block[block.startIndex..<block.endIndex])
+        var t = [UInt32](repeating: 0, count: 4)
+        #else
         var b = toUInt32Array(block[block.startIndex..<block.endIndex])
-
         var t = [UInt32](count: 4, repeatedValue: 0)
+        #endif
 
-        for r in (2...rounds).reverse() {
+        #if swift(>=3.0)
+        let reverse = (2...rounds).reversed()
+        #else
+        let reverse = (2...rounds).reverse()
+        #endif
+        for r in reverse {
             t[0] = b[0] ^ rk[r][0]
             t[1] = b[1] ^ rk[r][1]
             t[2] = b[2] ^ rk[r][2]
@@ -768,29 +928,56 @@ final private class AESCipher {
 
         // rounds
 
+        #if swift(>=3.0)
+        let lb00 = sBoxInv[Int(B0(x: t[0]))]
+        let lb01 = (sBoxInv[Int(B1(x: t[3]))] << 8)
+        let lb02 = (sBoxInv[Int(B2(x: t[2]))] << 16)
+        let lb03 = (sBoxInv[Int(B3(x: t[1]))] << 24)
+        b[0] = lb00 | lb01 | lb02 | lb03 ^ rk[0][0]
+
+        let lb10 = sBoxInv[Int(B0(x: t[1]))]
+        let lb11 = (sBoxInv[Int(B1(x: t[0]))] << 8)
+        let lb12 = (sBoxInv[Int(B2(x: t[3]))] << 16)
+        let lb13 = (sBoxInv[Int(B3(x: t[2]))] << 24)
+        b[1] = lb10 | lb11 | lb12 | lb13 ^ rk[0][1]
+
+        let lb20 = sBoxInv[Int(B0(x: t[2]))]
+        let lb21 = (sBoxInv[Int(B1(x: t[1]))] << 8)
+        let lb22 = (sBoxInv[Int(B2(x: t[0]))] << 16)
+        let lb23 = (sBoxInv[Int(B3(x: t[3]))] << 24)
+        b[2] = lb20 | lb21 | lb22 | lb23 ^ rk[0][2]
+
+        let lb30 = sBoxInv[Int(B0(x: t[3]))]
+        let lb31 = (sBoxInv[Int(B1(x: t[2]))] << 8)
+        let lb32 = (sBoxInv[Int(B2(x: t[1]))] << 16)
+        let lb33 = (sBoxInv[Int(B3(x: t[0]))] << 24)
+        b[3] = lb30 | lb31 | lb32 | lb33 ^ rk[0][3]
+        #else
         let lb00 = sBoxInv[Int(B0(t[0]))]
         let lb01 = (sBoxInv[Int(B1(t[3]))] << 8)
         let lb02 = (sBoxInv[Int(B2(t[2]))] << 16)
         let lb03 = (sBoxInv[Int(B3(t[1]))] << 24)
         b[0] = lb00 | lb01 | lb02 | lb03 ^ rk[0][0]
-
+        
         let lb10 = sBoxInv[Int(B0(t[1]))]
         let lb11 = (sBoxInv[Int(B1(t[0]))] << 8)
         let lb12 = (sBoxInv[Int(B2(t[3]))] << 16)
         let lb13 = (sBoxInv[Int(B3(t[2]))] << 24)
         b[1] = lb10 | lb11 | lb12 | lb13 ^ rk[0][1]
-
+        
         let lb20 = sBoxInv[Int(B0(t[2]))]
         let lb21 = (sBoxInv[Int(B1(t[1]))] << 8)
         let lb22 = (sBoxInv[Int(B2(t[0]))] << 16)
         let lb23 = (sBoxInv[Int(B3(t[3]))] << 24)
         b[2] = lb20 | lb21 | lb22 | lb23 ^ rk[0][2]
-
+        
         let lb30 = sBoxInv[Int(B0(t[3]))]
         let lb31 = (sBoxInv[Int(B1(t[2]))] << 8)
         let lb32 = (sBoxInv[Int(B2(t[1]))] << 16)
         let lb33 = (sBoxInv[Int(B3(t[0]))] << 24)
         b[3] = lb30 | lb31 | lb32 | lb33 ^ rk[0][3]
+        #endif
+
 
         var out = [UInt8]()
         out.reserveCapacity(b.count * 4)
@@ -806,22 +993,40 @@ final private class AESCipher {
 
     private func expandKeyInv(key: [UInt8], variant: AESVariant) -> [[UInt32]] {
         let rounds = variant.Nr
+        #if swift(>=3.0)
+        var rk2: [[UInt32]] = expandKey(key: key, variant: variant)
+        #else
         var rk2: [[UInt32]] = expandKey(key, variant: variant)
+        #endif
 
         for r in 1..<rounds {
             var w: UInt32
 
+            #if swift(>=3.0)
             w = rk2[r][0]
-            rk2[r][0] = U1[Int(B0(w))] ^ U2[Int(B1(w))] ^ U3[Int(B2(w))] ^ U4[Int(B3(w))]
+            rk2[r][0] = U1[Int(B0(x: w))] ^ U2[Int(B1(x: w))] ^ U3[Int(B2(x: w))] ^ U4[Int(B3(x: w))]
 
             w = rk2[r][1]
-            rk2[r][1] = U1[Int(B0(w))] ^ U2[Int(B1(w))] ^ U3[Int(B2(w))] ^ U4[Int(B3(w))]
+            rk2[r][1] = U1[Int(B0(x: w))] ^ U2[Int(B1(x: w))] ^ U3[Int(B2(x: w))] ^ U4[Int(B3(x: w))]
 
             w = rk2[r][2]
-            rk2[r][2] = U1[Int(B0(w))] ^ U2[Int(B1(w))] ^ U3[Int(B2(w))] ^ U4[Int(B3(w))]
+            rk2[r][2] = U1[Int(B0(x: w))] ^ U2[Int(B1(x: w))] ^ U3[Int(B2(x: w))] ^ U4[Int(B3(x: w))]
 
             w = rk2[r][3]
+            rk2[r][3] = U1[Int(B0(x: w))] ^ U2[Int(B1(x: w))] ^ U3[Int(B2(x: w))] ^ U4[Int(B3(x: w))]
+            #else
+            w = rk2[r][0]
+            rk2[r][0] = U1[Int(B0(w))] ^ U2[Int(B1(w))] ^ U3[Int(B2(w))] ^ U4[Int(B3(w))]
+            
+            w = rk2[r][1]
+            rk2[r][1] = U1[Int(B0(w))] ^ U2[Int(B1(w))] ^ U3[Int(B2(w))] ^ U4[Int(B3(w))]
+            
+            w = rk2[r][2]
+            rk2[r][2] = U1[Int(B0(w))] ^ U2[Int(B1(w))] ^ U3[Int(B2(w))] ^ U4[Int(B3(w))]
+            
+            w = rk2[r][3]
             rk2[r][3] = U1[Int(B0(w))] ^ U2[Int(B1(w))] ^ U3[Int(B2(w))] ^ U4[Int(B3(w))]
+            #endif
         }
 
         return rk2
@@ -831,16 +1036,32 @@ final private class AESCipher {
 
         func convertExpandedKey(expanded: [UInt8]) -> [[UInt32]] {
             var arr = [UInt32]()
+            #if swift(>=3.0)
+            for idx in stride(from: expanded.startIndex, to: expanded.endIndex, by: 4) {
+                let four = Array(expanded[idx..<expanded.index(idx, offsetBy: 4)].reversed())
+                let num = UInt32.withBytes(bytes: four)
+                arr.append(num)
+            }
+            #else
             for idx in expanded.startIndex.stride(to: expanded.endIndex, by: 4) {
                 let four = Array(expanded[idx..<idx.advancedBy(4)].reverse())
                 let num = UInt32.withBytes(four)
                 arr.append(num)
             }
+            #endif
 
             var allarr = [[UInt32]]()
+            #if swift(>=3.0)
+            for idx in stride(from: arr.startIndex, to: arr.endIndex, by: 4) {
+                allarr.append(Array(arr[idx..<arr.index(idx, offsetBy: 4)]))
+            }
+            #else
             for idx in arr.startIndex.stride(to: arr.endIndex, by: 4) {
                 allarr.append(Array(arr[idx..<idx.advancedBy(4)]))
             }
+            #endif
+
+
             return allarr
         }
 
@@ -857,7 +1078,11 @@ final private class AESCipher {
             return result
         }
 
+        #if swift(>=3.0)
+        var w = [UInt8](repeating:0, count: variant.Nb * (variant.Nr + 1) * 4)
+        #else
         var w = [UInt8](count: variant.Nb * (variant.Nr + 1) * 4, repeatedValue: 0)
+        #endif
         for i in 0..<variant.Nk {
             for wordIdx in 0..<4 {
                 w[(4*i)+wordIdx] = key[(4*i)+wordIdx]
@@ -867,16 +1092,28 @@ final private class AESCipher {
         var tmp: [UInt8]
 
         for i in variant.Nk..<variant.Nb * (variant.Nr + 1) {
+            #if swift(>=3.0)
+            tmp = [UInt8](repeating: 0, count: 4)
+            #else
             tmp = [UInt8](count: 4, repeatedValue: 0)
+            #endif
 
             for wordIdx in 0..<4 {
                 tmp[wordIdx] = w[4*(i-1)+wordIdx]
             }
             if (i % variant.Nk) == 0 {
+                #if swift(>=3.0)
+                tmp = subWord(word: rotateLeft(UInt32.withBytes(bytes: tmp), 8).bytes(totalBytes: sizeof(UInt32)))
+                #else
                 tmp = subWord(rotateLeft(UInt32.withBytes(tmp), 8).bytes(sizeof(UInt32)))
+                #endif
                 tmp[0] = tmp.first! ^ Rcon[i/variant.Nk]
             } else if variant.Nk > 6 && (i % variant.Nk) == 4 {
+                #if swift(>=3.0)
+                tmp = subWord(word: tmp)
+                #else
                 tmp = subWord(tmp)
+                #endif
             }
 
             // xor array of bytes
@@ -884,7 +1121,12 @@ final private class AESCipher {
                 w[4*i+wordIdx] = w[4*(i-variant.Nk)+wordIdx]^tmp[wordIdx]
             }
         }
+        #if swift(>=3.0)
+        return convertExpandedKey(expanded: w)
+        #else
         return convertExpandedKey(w)
+        #endif
+
     }
 }
 
@@ -908,15 +1150,26 @@ private extension AESCipher {
 
     private func F1(x0: UInt32, _ x1: UInt32, _ x2: UInt32, _ x3: UInt32) -> UInt32 {
         var result: UInt32 = 0
+        #if swift(>=3.0)
+        result |= UInt32(B1(x: T0[Int(x0 & 255)]))
+        result |= UInt32(B1(x: T0[Int((x1 >> 8) & 255)])) << 8
+        result |= UInt32(B1(x: T0[Int((x2 >> 16) & 255)])) << 16
+        result |= UInt32(B1(x: T0[Int(x3 >> 24)])) << 24
+        #else
         result |= UInt32(B1(T0[Int(x0 & 255)]))
         result |= UInt32(B1(T0[Int((x1 >> 8) & 255)])) << 8
         result |= UInt32(B1(T0[Int((x2 >> 16) & 255)])) << 16
         result |= UInt32(B1(T0[Int(x3 >> 24)])) << 24
+        #endif
         return result
     }
 
     private func calculateSBox() -> (sBox: [UInt32], invSBox: [UInt32]) {
+        #if swift(>=3.0)
+        var sbox = [UInt32](repeating: 0, count: 256)
+        #else
         var sbox = [UInt32](count: 256, repeatedValue: 0)
+        #endif
         var invsbox = sbox
         sbox[0] = 0x63
 
@@ -929,7 +1182,11 @@ private extension AESCipher {
             q ^= q << 4
             q ^= (q & 0x80) == 0x80 ? 0x09 : 0
 
+            #if swift(>=3.0)
             let s = 0x63 ^ q ^ rotateLeft(q, 1) ^ rotateLeft(q, 2) ^ rotateLeft(q, 3) ^ rotateLeft(q, 4)
+            #else
+            let s = 0x63 ^ q ^ rotateLeft(q, 1) ^ rotateLeft(q, 2) ^ rotateLeft(q, 3) ^ rotateLeft(q, 4)
+            #endif
 
             sbox[Int(p)] = UInt32(s)
             invsbox[Int(s)] = UInt32(p)
@@ -943,11 +1200,19 @@ private extension AESCipher {
 
 private extension AESCipher {
     convenience init(key: String, iv: String) throws {
+        #if swift(>=3.0)
+        guard let kkey = key.data(using: NSUTF8StringEncoding,
+            allowLossyConversion: false)?.arrayOfBytes(),
+            let iiv = iv.data(using: NSUTF8StringEncoding, allowLossyConversion: false)?.arrayOfBytes() else {
+            throw Error.InvalidKeyOrInitializationVector
+        }
+        #else
         guard let kkey = key.dataUsingEncoding(NSUTF8StringEncoding,
             allowLossyConversion: false)?.arrayOfBytes(),
             let iiv = iv.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)?.arrayOfBytes() else {
             throw Error.InvalidKeyOrInitializationVector
         }
+        #endif
 
         try self.init(key: kkey, iv: iiv)
     }
@@ -959,9 +1224,15 @@ private extension AESCipher {
 private typealias CipherOperationOnBlock = (block: [UInt8]) -> [UInt8]?
 
 private struct CBCBlockMode {
+    #if swift(>=3.0)
+    enum BlockError: ErrorProtocol {
+        case MissingInitializationVector
+    }
+    #else
     enum BlockError: ErrorType {
         case MissingInitializationVector
     }
+    #endif
 
     private func encryptBlocks(blocks: [[UInt8]], iv: [UInt8]?,
         cipherOperation: CipherOperationOnBlock) throws -> [UInt8] {
@@ -974,10 +1245,17 @@ private struct CBCBlockMode {
         out.reserveCapacity(blocks.count * blocks[blocks.startIndex].count)
         var prevCiphertext = iv // for the first time prevCiphertext = iv
         for plaintext in blocks {
+            #if swift(>=3.0)
+            if let encrypted = cipherOperation(block: xor(a: prevCiphertext, plaintext)) {
+                out.append(contentsOf: encrypted)
+                prevCiphertext = encrypted
+            }
+            #else
             if let encrypted = cipherOperation(block: xor(prevCiphertext, plaintext)) {
                 out.appendContentsOf(encrypted)
                 prevCiphertext = encrypted
             }
+            #endif
         }
         return out
     }
@@ -994,7 +1272,11 @@ private struct CBCBlockMode {
         var prevCiphertext = iv // for the first time prevCiphertext = iv
         for ciphertext in blocks {
             if let decrypted = cipherOperation(block: ciphertext) { // decrypt
+                #if swift(>=3.0)
+                out.append(contentsOf: xor(a: prevCiphertext, decrypted))
+                #else
                 out.appendContentsOf(xor(prevCiphertext, decrypted))
+                #endif
             }
             prevCiphertext = ciphertext
         }
@@ -1007,9 +1289,15 @@ private struct CBCBlockMode {
 
 private struct PKCS7 {
 
+    #if swift(>=3.0)
+    enum Error: ErrorProtocol {
+        case InvalidPaddingValue
+    }
+    #else
     enum Error: ErrorType {
         case InvalidPaddingValue
     }
+    #endif
 
     init() {
 
@@ -1021,12 +1309,20 @@ private struct PKCS7 {
         if padding == 0 {
             // If the original data is a multiple of N bytes, then an extra block of bytes with value N is added.
             for _ in 0..<blockSize {
+                #if swift(>=3.0)
+                withPadding.append(contentsOf: [UInt8(blockSize)])
+                #else
                 withPadding.appendContentsOf([UInt8(blockSize)])
+                #endif
             }
         } else {
             // The value of each added byte is the number of bytes that are added
             for _ in 0..<padding {
-                withPadding.appendContentsOf([UInt8(padding)])
+                #if swift(>=3.0)
+                    withPadding.append(contentsOf: [UInt8(padding)])
+                #else
+                    withPadding.appendContentsOf([UInt8(padding)])
+                #endif
             }
         }
         return withPadding
@@ -1051,13 +1347,27 @@ private struct PKCS7 {
 // MARK: - Utils
 
 private func xor(a: [UInt8], _ b: [UInt8]) -> [UInt8] {
+    #if swift(>=3.0)
+    var xored = [UInt8](repeating: 0, count: min(a.count, b.count))
+    #else
     var xored = [UInt8](count: min(a.count, b.count), repeatedValue: 0)
+    #endif
     for i in 0..<xored.count {
         xored[i] = a[i] ^ b[i]
     }
     return xored
 }
 
+
+#if swift(>=3.0)
+private func rotateLeft(_ v: UInt8, _ n: UInt8) -> UInt8 {
+    return ((v << n) & 0xFF) | (v >> (8 - n))
+}
+
+private func rotateLeft(_ v: UInt32, _ n: UInt32) -> UInt32 {
+    return ((v << n) & 0xFFFFFFFF) | (v >> (32 - n))
+}
+#else
 private func rotateLeft(v: UInt8, _ n: UInt8) -> UInt8 {
     return ((v << n) & 0xFF) | (v >> (8 - n))
 }
@@ -1065,12 +1375,19 @@ private func rotateLeft(v: UInt8, _ n: UInt8) -> UInt8 {
 private func rotateLeft(v: UInt32, _ n: UInt32) -> UInt32 {
     return ((v << n) & 0xFFFFFFFF) | (v >> (32 - n))
 }
+#endif
 
 private protocol BitshiftOperationsType {
     func << (lhs: Self, rhs: Self) -> Self
     func >> (lhs: Self, rhs: Self) -> Self
+    #if swift(>=3.0)
+    func <<= (lhs: inout Self, rhs: Self)
+    func >>= (lhs: inout Self, rhs: Self)
+    #else
     func <<= (inout lhs: Self, rhs: Self)
     func >>= (inout lhs: Self, rhs: Self)
+    #endif
+    
 }
 
 private protocol ByteConvertible {
@@ -1097,12 +1414,13 @@ extension UInt64 : BitshiftOperationsType, ByteConvertible {
     }
 }
 
-private func integerWithBytes<T: IntegerType where T:ByteConvertible, T: BitshiftOperationsType>(bytes: [UInt8]) -> T {
-    var bytes = bytes.reverse() as Array<UInt8>
+#if swift(>=3.0)
+private func integerWithBytes<T: Integer where T:ByteConvertible, T: BitshiftOperationsType>(bytes: [UInt8]) -> T {
+    var bytes = bytes.reversed() as Array<UInt8>
     if bytes.count < sizeof(T) {
         let paddingCount = sizeof(T) - bytes.count
         if paddingCount > 0 {
-            bytes += [UInt8](count: paddingCount, repeatedValue: 0)
+            bytes += [UInt8](repeating: 0, count: paddingCount)
         }
     }
 
@@ -1111,21 +1429,50 @@ private func integerWithBytes<T: IntegerType where T:ByteConvertible, T: Bitshif
     }
 
     var result: T = 0
+    for byte in bytes.reversed() {
+        result = result << 8 | T(byte)
+    }
+    return result
+}
+#else
+private func integerWithBytes<T: IntegerType where T:ByteConvertible, T: BitshiftOperationsType>(bytes: [UInt8]) -> T {
+    var bytes = bytes.reverse() as Array<UInt8>
+    if bytes.count < sizeof(T) {
+        let paddingCount = sizeof(T) - bytes.count
+        if paddingCount > 0 {
+            bytes += [UInt8](count: paddingCount, repeatedValue: 0)
+        }
+    }
+    
+    if sizeof(T) == 1 {
+        return T(truncatingBitPattern: UInt64(bytes.first!))
+    }
+    
+    var result: T = 0
     for byte in bytes.reverse() {
         result = result << 8 | T(byte)
     }
     return result
 }
+#endif
 
 private extension UInt32 {
 
     private func bytes(totalBytes: Int = sizeof(UInt32)) -> [UInt8] {
+        #if swift(>=3.0)
+        return arrayOfBytes(value: self, length: totalBytes)
+        #else
         return arrayOfBytes(self, length: totalBytes)
+        #endif
     }
 
     /** Int with array bytes (little-endian) */
     private static func withBytes(bytes: [UInt8]) -> UInt32 {
+        #if swift(>=3.0)
+        return integerWithBytes(bytes: bytes)
+        #else
         return integerWithBytes(bytes)
+        #endif
     }
 }
 
@@ -1133,6 +1480,16 @@ private func toUInt32Array(slice: ArraySlice<UInt8>) -> Array<UInt32> {
     var result = Array<UInt32>()
     result.reserveCapacity(16)
 
+    #if swift(>=3.0)
+    for idx in stride(from: slice.startIndex, to: slice.endIndex, by: sizeof(UInt32)) {
+        let val1: UInt32 = (UInt32(slice[slice.index(idx, offsetBy: 3)]) << 24)
+        let val2: UInt32 = (UInt32(slice[slice.index(idx, offsetBy: 2)]) << 16)
+        let val3: UInt32 = (UInt32(slice[slice.index(idx, offsetBy: 1)]) << 8)
+        let val4: UInt32 = UInt32(slice[idx])
+        let val: UInt32 = val1 | val2 | val3 | val4
+        result.append(val)
+    }
+    #else
     for idx in slice.startIndex.stride(to: slice.endIndex, by: sizeof(UInt32)) {
         let val1: UInt32 = (UInt32(slice[idx.advancedBy(3)]) << 24)
         let val2: UInt32 = (UInt32(slice[idx.advancedBy(2)]) << 16)
@@ -1141,6 +1498,8 @@ private func toUInt32Array(slice: ArraySlice<UInt8>) -> Array<UInt32> {
         let val: UInt32 = val1 | val2 | val3 | val4
         result.append(val)
     }
+    #endif
+
     return result
 }
 
@@ -1149,21 +1508,34 @@ private func toUInt32Array(slice: ArraySlice<UInt8>) -> Array<UInt32> {
 private func arrayOfBytes<T>(value: T, length: Int? = nil) -> [UInt8] {
     let totalBytes = length ?? sizeof(T)
 
+    #if swift(>=3.0)
+    let valuePointer = UnsafeMutablePointer<T>(allocatingCapacity: 1)
+    valuePointer.pointee = value
+
+    let bytesPointer = UnsafeMutablePointer<UInt8>(valuePointer)
+    var bytes = [UInt8](repeating: 0, count: totalBytes)
+    for j in 0..<min(sizeof(T), totalBytes) {
+        bytes[totalBytes - 1 - j] = (bytesPointer + j).pointee
+    }
+
+    valuePointer.deinitialize()
+    valuePointer.deallocateCapacity(1)
+    #else
     let valuePointer = UnsafeMutablePointer<T>.alloc(1)
     valuePointer.memory = value
-
+    
     let bytesPointer = UnsafeMutablePointer<UInt8>(valuePointer)
     var bytes = [UInt8](count: totalBytes, repeatedValue: 0)
     for j in 0..<min(sizeof(T), totalBytes) {
         bytes[totalBytes - 1 - j] = (bytesPointer + j).memory
     }
-
+    
     valuePointer.destroy()
     valuePointer.dealloc(1)
+    #endif
 
     return bytes
 }
-
 
 private extension Array {
 
@@ -1192,7 +1564,11 @@ private extension NSData {
 
     private func arrayOfBytes() -> [UInt8] {
         let count = self.length / sizeof(UInt8)
+        #if swift(>=3.0)
+        var bytesArray = [UInt8](repeating: 0, count: count)
+        #else
         var bytesArray = [UInt8](count: count, repeatedValue: 0)
+        #endif
         self.getBytes(&bytesArray, length:count * sizeof(UInt8))
         return bytesArray
     }

--- a/sources/BaseDestination.swift
+++ b/sources/BaseDestination.swift
@@ -83,21 +83,34 @@ public class BaseDestination: Hashable, Equatable {
     var queue: dispatch_queue_t?
 
     public init() {
+        #if swift(>=3.0)
+        let uuid = NSUUID().uuidString
+        #else
         let uuid = NSUUID().UUIDString
+        #endif
         let queueLabel = "swiftybeaver-queue-" + uuid
         queue = dispatch_queue_create(queueLabel, DISPATCH_QUEUE_SERIAL)
     }
 
     /// overrule the destination’s minLevel for a given path and optional function
+    #if swift(>=3.0)
+    public func addMinLevelFilter(_ minLevel: SwiftyBeaver.Level, path: String, function: String = "") {
+        let filter = MinLevelFilter(minLevel: minLevel, path: path, function: function)
+        minLevelFilters.append(filter)
+    }
+    #else
     public func addMinLevelFilter(minLevel: SwiftyBeaver.Level, path: String, function: String = "") {
         let filter = MinLevelFilter(minLevel: minLevel, path: path, function: function)
         minLevelFilters.append(filter)
     }
+    #endif
+
 
     /// send / store the formatted log message to the destination
     /// returns the formatted log message for processing by inheriting method
     /// and for unit tests (nil if error)
-    public func send(level: SwiftyBeaver.Level, msg: String, thread: String,
+    #if swift(>=3.0)
+    public func send(_ level: SwiftyBeaver.Level, msg: String, thread: String,
         path: String, function: String, line: Int) -> String? {
         var dateStr = ""
         var str = ""
@@ -109,25 +122,60 @@ public class BaseDestination: Hashable, Equatable {
             function: function, line: line, detailOutput: detailOutput)
         return str
     }
+    #else
+    public func send(level: SwiftyBeaver.Level, msg: String, thread: String,
+                     path: String, function: String, line: Int) -> String? {
+        var dateStr = ""
+        var str = ""
+        let levelStr = formattedLevel(level)
+        let formattedMsg = coloredMessage(msg, forLevel: level)
+        
+        dateStr = formattedDate(dateFormat)
+        str = formattedMessage(dateStr, levelString: levelStr, msg: formattedMsg, thread: thread, path: path,
+                               function: function, line: line, detailOutput: detailOutput)
+        return str
+    }
+    #endif
 
     /// returns a formatted date string
+    #if swift(>=3.0)
+    func formattedDate(_ dateFormat: String) -> String {
+        //formatter.timeZone = NSTimeZone(abbreviation: "UTC")
+        formatter.dateFormat = dateFormat
+        let dateStr = formatter.string(from: NSDate())
+        return dateStr
+    }
+    #else
     func formattedDate(dateFormat: String) -> String {
         //formatter.timeZone = NSTimeZone(abbreviation: "UTC")
         formatter.dateFormat = dateFormat
         let dateStr = formatter.stringFromDate(NSDate())
         return dateStr
     }
+    #endif
 
     /// returns the log message entirely colored
-    func coloredMessage(msg: String, forLevel level: SwiftyBeaver.Level) -> String {
+    #if swift(>=3.0)
+    func coloredMessage(_ msg: String, forLevel level: SwiftyBeaver.Level) -> String {
         if !(colored && coloredLines) {
             return msg
         }
 
+        let color = colorForLevel(level: level)
+        let coloredMsg = escape + color + msg + reset
+        return coloredMsg
+    }
+    #else
+    func coloredMessage(msg: String, forLevel level: SwiftyBeaver.Level) -> String {
+        if !(colored && coloredLines) {
+            return msg
+        }
+        
         let color = colorForLevel(level)
         let coloredMsg = escape + color + msg + reset
         return coloredMsg
     }
+    #endif
 
     /// returns color string for level
     func colorForLevel(level: SwiftyBeaver.Level) -> String {
@@ -154,9 +202,10 @@ public class BaseDestination: Hashable, Equatable {
     }
 
     /// returns an optionally colored level noun (like INFO, etc.)
-    func formattedLevel(level: SwiftyBeaver.Level) -> String {
+    #if swift(>=3.0)
+    func formattedLevel(_ level: SwiftyBeaver.Level) -> String {
         // optionally wrap the level string in color
-        let color = colorForLevel(level)
+        let color = colorForLevel(level: level)
         var levelStr = ""
 
         switch level {
@@ -182,12 +231,46 @@ public class BaseDestination: Hashable, Equatable {
         }
         return levelStr
     }
+    #else
+    func formattedLevel(level: SwiftyBeaver.Level) -> String {
+        // optionally wrap the level string in color
+        let color = colorForLevel(level)
+        var levelStr = ""
+        
+        switch level {
+        case SwiftyBeaver.Level.Debug:
+            levelStr = levelString.Debug
+            
+        case SwiftyBeaver.Level.Info:
+            levelStr = levelString.Info
+            
+        case SwiftyBeaver.Level.Warning:
+            levelStr = levelString.Warning
+            
+        case SwiftyBeaver.Level.Error:
+            levelStr = levelString.Error
+            
+        default:
+            // Verbose is default
+            levelStr = levelString.Verbose
+        }
+        
+        if colored {
+            levelStr = escape + color + levelStr + reset
+        }
+        return levelStr
+    }
+    #endif
+
+
 
     /// returns the formatted log message
-    func formattedMessage(dateString: String, levelString: String, msg: String,
+    #if swift(>=3.0)
+    func formattedMessage(_ dateString: String, levelString: String, msg: String,
         thread: String, path: String, function: String, line: Int, detailOutput: Bool) -> String {
         // just use the file name of the path and remove suffix
-        let file = path.componentsSeparatedByString("/").last!.componentsSeparatedByString(".").first!
+        let file = path.components(separatedBy: "/").last!.components(separatedBy: ".").first!
+
         var str = ""
         if dateString != "" {
              str += "[\(dateString)] "
@@ -203,9 +286,53 @@ public class BaseDestination: Hashable, Equatable {
         }
         return str
     }
+    #else
+    func formattedMessage(dateString: String, levelString: String, msg: String,
+                          thread: String, path: String, function: String, line: Int, detailOutput: Bool) -> String {
+        // just use the file name of the path and remove suffix
+        let file = path.componentsSeparatedByString("/").last!.componentsSeparatedByString(".").first!
+        
+        var str = ""
+        if dateString != "" {
+            str += "[\(dateString)] "
+        }
+        if detailOutput {
+            if thread != "main" && thread != "" {
+                str += "|\(thread)| "
+            }
+            
+            str += "\(file).\(function):\(line) \(levelString): \(msg)"
+        } else {
+            str += "\(levelString): \(msg)"
+        }
+        return str
+    }
+    #endif
+
 
     /// checks if level is at least minLevel or if a minLevel filter for that path does exist
     /// returns boolean and can be used to decide if a message should be logged or not
+    #if swift(>=3.0)
+    func shouldLevelBeLogged(_ level: SwiftyBeaver.Level, path: String, function: String) -> Bool {
+        // at first check the instance’s global minLevel property
+        if minLevel.rawValue <= level.rawValue {
+            return true
+        }
+        // now go through all minLevelFilters and see if there is a match
+        for filter in minLevelFilters {
+            // rangeOfString returns nil if both values are the same!
+            if filter.minLevel.rawValue <= level.rawValue {
+                if filter.path == "" || path == filter.path || path.range(of: filter.path) != nil {
+                    if filter.function == "" || function == filter.function ||
+                        function.range(of: filter.function) != nil {
+                        return true
+                    }
+                }
+            }
+        }
+        return false
+    }
+    #else
     func shouldLevelBeLogged(level: SwiftyBeaver.Level, path: String, function: String) -> Bool {
         // at first check the instance’s global minLevel property
         if minLevel.rawValue <= level.rawValue {
@@ -225,6 +352,8 @@ public class BaseDestination: Hashable, Equatable {
         }
         return false
     }
+    #endif
+
 
   /**
     Triggered by main flush() method on each destination. Runs in background thread.

--- a/sources/ConsoleDestination.swift
+++ b/sources/ConsoleDestination.swift
@@ -20,7 +20,8 @@ public class ConsoleDestination: BaseDestination {
     }
 
     // print to Xcode Console. uses full base class functionality
-    override public func send(level: SwiftyBeaver.Level, msg: String, thread: String,
+    #if swift(>=3.0)
+    override public func send(_ level: SwiftyBeaver.Level, msg: String, thread: String,
         path: String, function: String, line: Int) -> String? {
         let formattedString = super.send(level, msg: msg, thread: thread, path: path, function: function, line: line)
 
@@ -33,4 +34,20 @@ public class ConsoleDestination: BaseDestination {
         }
         return formattedString
     }
+    #else
+    override public func send(level: SwiftyBeaver.Level, msg: String, thread: String,
+        path: String, function: String, line: Int) -> String? {
+        let formattedString = super.send(level, msg: msg, thread: thread, path: path, function: function, line: line)
+        
+        if let str = formattedString {
+            if useNSLog {
+                NSLog(str)
+            } else {
+                print(str)
+            }
+        }
+        return formattedString
+    }
+    #endif
+
 }

--- a/sources/FileDestination.swift
+++ b/sources/FileDestination.swift
@@ -14,22 +14,40 @@ public class FileDestination: BaseDestination {
     public var logFileURL: NSURL
 
     override public var defaultHashValue: Int {return 2}
+    #if swift(>=3.0)
+    let fileManager = NSFileManager.default()
+    #else
     let fileManager = NSFileManager.defaultManager()
+    #endif
     var fileHandle: NSFileHandle? = nil
 
     public override init() {
         // platform-dependent logfile directory default
-        var logsBaseDir: NSSearchPathDirectory = .CachesDirectory
+        #if swift(>=3.0)
+        var logsBaseDir: NSSearchPathDirectory = .cachesDirectory
 
+        if OS == "OSX" {
+            logsBaseDir = .documentDirectory
+        }
+
+        if let url = fileManager.urlsForDirectory(logsBaseDir, inDomains: .userDomainMask).first {
+            logFileURL = url.appendingPathComponent("swiftybeaver.log", isDirectory: false)
+        } else {
+            logFileURL = NSURL()
+        }
+        #else
+        var logsBaseDir: NSSearchPathDirectory = .CachesDirectory
+        
         if OS == "OSX" {
             logsBaseDir = .DocumentDirectory
         }
-
+        
         if let url = fileManager.URLsForDirectory(logsBaseDir, inDomains: .UserDomainMask).first {
             logFileURL = url.URLByAppendingPathComponent("swiftybeaver.log", isDirectory: false)
         } else {
             logFileURL = NSURL()
         }
+        #endif
         super.init()
 
         // bash font color, first value is intensity, second is color
@@ -45,6 +63,17 @@ public class FileDestination: BaseDestination {
     }
 
     // append to file. uses full base class functionality
+    #if swift(>=3.0)
+    override public func send(_ level: SwiftyBeaver.Level, msg: String, thread: String,
+        path: String, function: String, line: Int) -> String? {
+        let formattedString = super.send(level, msg: msg, thread: thread, path: path, function: function, line: line)
+
+        if let str = formattedString {
+            saveToFile(str, url: logFileURL)
+        }
+        return formattedString
+    }
+    #else
     override public func send(level: SwiftyBeaver.Level, msg: String, thread: String,
         path: String, function: String, line: Int) -> String? {
         let formattedString = super.send(level, msg: msg, thread: thread, path: path, function: function, line: line)
@@ -54,6 +83,7 @@ public class FileDestination: BaseDestination {
         }
         return formattedString
     }
+    #endif
 
     deinit {
         // close file handle if set
@@ -64,6 +94,33 @@ public class FileDestination: BaseDestination {
 
     /// appends a string as line to a file.
     /// returns boolean about success
+    #if swift(>=3.0)
+    func saveToFile(_ str: String, url: NSURL) -> Bool {
+        do {
+            if fileManager.fileExists(atPath: url.path!) == false {
+                // create file if not existing
+                let line = str + "\n"
+                try line.write(to: url, atomically: true, encoding: NSUTF8StringEncoding)
+            } else {
+                // append to end of file
+                if fileHandle == nil {
+                    // initial setting of file handle
+                    fileHandle = try NSFileHandle(forWritingTo: url)
+                }
+                if let fileHandle = fileHandle {
+                    fileHandle.seekToEndOfFile()
+                    let line = str + "\n"
+                    let data = line.data(using: NSUTF8StringEncoding)!
+                    fileHandle.write(data)
+                }
+            }
+            return true
+        } catch let error {
+            print("SwiftyBeaver File Destination could not write to file \(url). \(error)")
+            return false
+        }
+    }
+    #else
     func saveToFile(str: String, url: NSURL) -> Bool {
         do {
             if fileManager.fileExistsAtPath(url.path!) == false {
@@ -89,4 +146,5 @@ public class FileDestination: BaseDestination {
             return false
         }
     }
+    #endif
 }

--- a/sources/SBPlatformDestination.swift
+++ b/sources/SBPlatformDestination.swift
@@ -30,7 +30,11 @@ import Foundation
 #endif
 
 #if os(iOS) || os(tvOS)
-    var DEVICE_NAME = UIDevice.currentDevice().name
+    #if swift(>=3.0)
+        var DEVICE_NAME = UIDevice.current().name
+    #else
+        var DEVICE_NAME = UIDevice.currentDevice().name
+    #endif
 #else
     // under watchOS UIDevice is not existing, http://apple.co/26ch5J1
     let DEVICE_NAME = ""
@@ -76,7 +80,11 @@ public class SBPlatformDestination: BaseDestination {
 
     // destination
     override public var defaultHashValue: Int {return 3}
+    #if swift(>=3.0)
+    let fileManager = NSFileManager.default()
+    #else
     let fileManager = NSFileManager.defaultManager()
+    #endif
     let isoDateFormatter = NSDateFormatter()
 
 
@@ -89,60 +97,85 @@ public class SBPlatformDestination: BaseDestination {
         // setup where to write the json files
         var baseURL: NSURL?
         if OS == "OSX" {
+            #if swift(>=3.0)
+            if let url = fileManager.urlsForDirectory(.applicationSupportDirectory, inDomains: .userDomainMask).first {
+                baseURL = url
+            }
+            #else
             if let url = fileManager.URLsForDirectory(.ApplicationSupportDirectory, inDomains: .UserDomainMask).first {
                 baseURL = url
             }
+            #endif
+
         } else {
             // iOS, watchOS, etc. are using the document directory of the app
+            #if swift(>=3.0)
+            if let url = fileManager.urlsForDirectory(.documentDirectory, inDomains: .userDomainMask).first {
+                baseURL = url
+            }
+            #else
             if let url = fileManager.URLsForDirectory(.DocumentDirectory, inDomains: .UserDomainMask).first {
                 baseURL = url
             }
+            #endif
+
         }
 
         if let baseURL = baseURL {
+            #if swift(>=3.0)
+            entriesFileURL = baseURL.appendingPathComponent("sbplatform_entries.json", isDirectory: false)
+            sendingFileURL = baseURL.appendingPathComponent("sbplatform_entries_sending.json", isDirectory: false)
+            analyticsFileURL = baseURL.appendingPathComponent("sbplatform_analytics.json", isDirectory: false)
+                
+            // get, update loaded and save analytics data to file on start
+            let dict = analytics(analyticsFileURL, update: true)
+            #else
             entriesFileURL = baseURL.URLByAppendingPathComponent("sbplatform_entries.json", isDirectory: false)
             sendingFileURL = baseURL.URLByAppendingPathComponent("sbplatform_entries_sending.json", isDirectory: false)
             analyticsFileURL = baseURL.URLByAppendingPathComponent("sbplatform_analytics.json", isDirectory: false)
-
+                
             // get, update loaded and save analytics data to file on start
             let dict = analytics(analyticsFileURL, update: true)
+            #endif
             saveDictToFile(dict, url: analyticsFileURL)
         }
     }
 
 
     // append to file, each line is a JSON dict
-    override public func send(level: SwiftyBeaver.Level, msg: String, thread: String,
+    #if swift(>=3.0)
+    override public func send(_ level: SwiftyBeaver.Level, msg: String, thread: String,
         path: String, function: String, line: Int) -> String? {
 
         var jsonString: String?
+
         let dict: [String: AnyObject] = [
-                "timestamp": NSDate().timeIntervalSince1970,
-                "level": level.rawValue,
-                "message": msg,
-                "thread": thread,
-                "fileName": path.componentsSeparatedByString("/").last!,
-                "function": function,
-                "line":line]
-
+            "timestamp": NSDate().timeIntervalSince1970 as AnyObject,
+            "level": level.rawValue as AnyObject,
+            "message": msg as AnyObject,
+            "thread": thread as AnyObject,
+            "fileName": path.components(separatedBy: "/").last! as AnyObject,
+            "function": function as AnyObject,
+            "line":line as AnyObject]
+        
         jsonString = jsonStringFromDict(dict)
-
+        
         if let str = jsonString {
             toNSLog("saving '\(msg)' to file")
             saveToFile(str, url: entriesFileURL)
             //toNSLog(entriesFileURL.path!)
-
+            
             // now decide if the stored log entries should be sent to the server
             // add level points to current points amount and send to server if threshold is hit
             let newPoints = sendingPointsForLevel(level)
             points += newPoints
             toNSLog("current sending points: \(points)")
-
+            
             if points >= sendingPoints.Threshold || points > maxAllowedThreshold {
                 toNSLog("\(points) points is >= threshold")
                 // above threshold, send to server
                 sendNow()
-
+                
             } else if initialSending {
                 initialSending = false
                 // first logging at this session
@@ -158,8 +191,61 @@ public class SBPlatformDestination: BaseDestination {
                 }
             }
         }
+
         return jsonString
     }
+    #else
+    override public func send(level: SwiftyBeaver.Level, msg: String, thread: String,
+        path: String, function: String, line: Int) -> String? {
+
+        var jsonString: String?
+
+        let dict: [String: AnyObject] = [
+            "timestamp": NSDate().timeIntervalSince1970,
+            "level": level.rawValue,
+            "message": msg,
+            "thread": thread,
+            "fileName": path.componentsSeparatedByString("/").last!,
+            "function": function,
+            "line":line]
+        
+        jsonString = jsonStringFromDict(dict)
+        
+        if let str = jsonString {
+            toNSLog("saving '\(msg)' to file")
+            saveToFile(str, url: entriesFileURL)
+            //toNSLog(entriesFileURL.path!)
+            
+            // now decide if the stored log entries should be sent to the server
+            // add level points to current points amount and send to server if threshold is hit
+            let newPoints = sendingPointsForLevel(level)
+            points += newPoints
+            toNSLog("current sending points: \(points)")
+            
+            if points >= sendingPoints.Threshold || points > maxAllowedThreshold {
+                toNSLog("\(points) points is >= threshold")
+                // above threshold, send to server
+                sendNow()
+                
+            } else if initialSending {
+                initialSending = false
+                // first logging at this session
+                // send if json file still contains old log entries
+                if let logEntries = logsFromFile(entriesFileURL) {
+                    let lines = logEntries.count
+                    if lines > 1 {
+                        var msg = "initialSending: \(points) points is below threshold "
+                        msg += "but json file already has \(lines) lines."
+                        toNSLog(msg)
+                        sendNow()
+                    }
+                }
+            }
+        }
+
+        return jsonString
+    }
+    #endif
 
 
     // MARK: Send-to-Server Logic
@@ -180,24 +266,36 @@ public class SBPlatformDestination: BaseDestination {
             sendingInProgress = true
             //let (jsonString, lines) = logsFromFile(sendingFileURL)
             var lines = 0
+            
             guard let logEntries = logsFromFile(sendingFileURL) else {
                 sendingInProgress = false
                 return
             }
+            
             lines = logEntries.count
+
 
             if lines > 0 {
                 var payload = [String:AnyObject]()
                 // merge device and analytics dictionaries
                 let deviceDetailsDict = deviceDetails()
+                
                 var analyticsDict = analytics(analyticsFileURL)
 
+                #if swift(>=3.0)
+                for key in deviceDetailsDict.keys {
+                    analyticsDict[key] = deviceDetailsDict[key] as AnyObject?
+                }
+                payload["device"] = analyticsDict as AnyObject
+                payload["entries"] = logEntries as AnyObject
+                #else
                 for key in deviceDetailsDict.keys {
                     analyticsDict[key] = deviceDetailsDict[key]
                 }
                 payload["device"] = analyticsDict
                 payload["entries"] = logEntries
-
+                #endif
+                
                 if let str = jsonStringFromDict(payload) {
                     //toNSLog(str)  // uncomment to see full payload
                     toNSLog("Encrypting \(lines) log entries ...")
@@ -206,10 +304,10 @@ public class SBPlatformDestination: BaseDestination {
                         msg += "(\(encryptedStr.characters.count) chars) to server ..."
                         toNSLog(msg)
                         //toNSLog("Sending \(encryptedStr) ...")
-
+                        
                         sendToServerAsync(encryptedStr) {
                             ok, status in
-
+                            
                             self.toNSLog("Sent \(lines) encrypted log entries to server, received ok: \(ok)")
                             if ok {
                                 self.deleteFile(self.sendingFileURL)
@@ -226,7 +324,9 @@ public class SBPlatformDestination: BaseDestination {
     }
 
     /// sends a string to the SwiftyBeaver Platform server, returns ok if status 200 and HTTP status
-    func sendToServerAsync(str: String?, complete: (ok: Bool, status: Int) -> ()) {
+    
+    #if swift(>=3.0)
+    func sendToServerAsync(_ str: String?, complete: (ok: Bool, status: Int) -> ()) {
 
         if let payload = str, let queue = self.queue {
 
@@ -235,24 +335,24 @@ public class SBPlatformDestination: BaseDestination {
             operationQueue.underlyingQueue = queue
 
             let session = NSURLSession(configuration:
-                NSURLSessionConfiguration.defaultSessionConfiguration(),
+                NSURLSessionConfiguration.default(),
                 delegate: nil, delegateQueue: operationQueue)
 
             // assemble request
-            let request = NSMutableURLRequest(URL: serverURL)
-            request.HTTPMethod = "POST"
+            let request = NSMutableURLRequest(url: serverURL)
+            request.httpMethod = "POST"
             request.addValue("application/json", forHTTPHeaderField: "Content-Type")
             request.addValue("application/json", forHTTPHeaderField: "Accept")
 
             // basic auth header
-            let credentials = "\(appID):\(appSecret)".dataUsingEncoding(NSUTF8StringEncoding)!
-            let base64Credentials = credentials.base64EncodedStringWithOptions([])
+            let credentials = "\(appID):\(appSecret)".data(using: NSUTF8StringEncoding)!
+            let base64Credentials = credentials.base64EncodedString([])
             request.setValue("Basic \(base64Credentials)", forHTTPHeaderField: "Authorization")
 
             // POST parameters
             let params = ["payload": payload]
             do {
-                request.HTTPBody = try NSJSONSerialization.dataWithJSONObject(params, options: [])
+                request.httpBody = try NSJSONSerialization.data(withJSONObject: params as AnyObject, options: [])
             } catch let error as NSError {
                 toNSLog("Error! Could not create JSON for server payload. \(error)")
             }
@@ -261,7 +361,7 @@ public class SBPlatformDestination: BaseDestination {
 
             sendingInProgress = true
             // send request async to server on destination queue
-            let task = session.dataTaskWithRequest(request) {
+            let task = session.dataTask(with: request) {
                 _, response, error in
                 var ok = false
                 var status = 0
@@ -289,9 +389,76 @@ public class SBPlatformDestination: BaseDestination {
             task.resume()
         }
     }
+    #else
+    func sendToServerAsync(str: String?, complete: (ok: Bool, status: Int) -> ()) {
+        
+        if let payload = str, let queue = self.queue {
+            
+            // create operation queue which uses current serial queue of destination
+            let operationQueue = NSOperationQueue()
+            operationQueue.underlyingQueue = queue
+            
+            let session = NSURLSession(configuration:
+                NSURLSessionConfiguration.defaultSessionConfiguration(),
+                                       delegate: nil, delegateQueue: operationQueue)
+            
+            // assemble request
+            let request = NSMutableURLRequest(URL: serverURL)
+            request.HTTPMethod = "POST"
+            request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.addValue("application/json", forHTTPHeaderField: "Accept")
+            
+            // basic auth header
+            let credentials = "\(appID):\(appSecret)".dataUsingEncoding(NSUTF8StringEncoding)!
+            let base64Credentials = credentials.base64EncodedStringWithOptions([])
+            request.setValue("Basic \(base64Credentials)", forHTTPHeaderField: "Authorization")
+            
+            // POST parameters
+            let params = ["payload": payload]
+            do {
+                request.HTTPBody = try NSJSONSerialization.dataWithJSONObject(params, options: [])
+            } catch let error as NSError {
+                toNSLog("Error! Could not create JSON for server payload. \(error)")
+            }
+            //toNSLog("sending params: \(params)")
+            //toNSLog("\n\nbefore sendToServer on thread '\(threadName())'")
+            
+            sendingInProgress = true
+            // send request async to server on destination queue
+            let task = session.dataTaskWithRequest(request) {
+                _, response, error in
+                var ok = false
+                var status = 0
+                //toNSLog("callback of sendToServer on thread '\(self.threadName())'")
+                
+                if let error = error {
+                    // an error did occur
+                    self.toNSLog("Error! Could not send entries to server. \(error)")
+                } else {
+                    if let response = response as? NSHTTPURLResponse {
+                        status = response.statusCode
+                        if status == 200 {
+                            // all went well, entries were uploaded to server
+                            ok = true
+                        } else {
+                            // status code was not 200
+                            var msg = "Error! Sending entries to server failed "
+                            msg += "with status code \(status)"
+                            self.toNSLog(msg)
+                        }
+                    }
+                }
+                return complete(ok: ok, status: status)
+            }
+            task.resume()
+        }
+    }
+    #endif
+
 
     /// returns sending points based on level
-    func sendingPointsForLevel(level: SwiftyBeaver.Level) -> Int {
+    #if swift(>=3.0)
+    func sendingPointsForLevel(_ level: SwiftyBeaver.Level) -> Int {
 
         switch level {
         case SwiftyBeaver.Level.Debug:
@@ -306,12 +473,52 @@ public class SBPlatformDestination: BaseDestination {
             return sendingPoints.Verbose
         }
     }
+    #else
+    func sendingPointsForLevel(level: SwiftyBeaver.Level) -> Int {
+        
+        switch level {
+        case SwiftyBeaver.Level.Debug:
+            return sendingPoints.Debug
+        case SwiftyBeaver.Level.Info:
+            return sendingPoints.Info
+        case SwiftyBeaver.Level.Warning:
+            return sendingPoints.Warning
+        case SwiftyBeaver.Level.Error:
+            return sendingPoints.Error
+        default:
+            return sendingPoints.Verbose
+        }
+    }
+    #endif
 
 
     // MARK: File Handling
 
     /// appends a string as line to a file.
     /// returns boolean about success
+    #if swift(>=3.0)
+    func saveToFile(_ str: String, url: NSURL, overwrite: Bool = false) -> Bool {
+        do {
+            if fileManager.fileExists(atPath: url.path!) == false || overwrite {
+                // create file if not existing
+                let line = str + "\n"
+                try line.write(to: url, atomically: true, encoding: NSUTF8StringEncoding)
+            } else {
+                // append to end of file
+                let fileHandle = try NSFileHandle(forWritingTo: url)
+                fileHandle.seekToEndOfFile()
+                let line = str + "\n"
+                let data = line.data(using: NSUTF8StringEncoding)!
+                fileHandle.write(data)
+                fileHandle.closeFile()
+            }
+            return true
+        } catch let error {
+            toNSLog("Error! Could not write to file \(url). \(error)")
+            return false
+        }
+    }
+    #else
     func saveToFile(str: String, url: NSURL, overwrite: Bool = false) -> Bool {
         do {
             if fileManager.fileExistsAtPath(url.path!) == false || overwrite {
@@ -333,11 +540,29 @@ public class SBPlatformDestination: BaseDestination {
             return false
         }
     }
+    #endif
 
+    #if swift(>=3.0)
+    func sendFileExists() -> Bool {
+        return fileManager.fileExists(atPath: sendingFileURL.path!)
+    }
+    #else
     func sendFileExists() -> Bool {
         return fileManager.fileExistsAtPath(sendingFileURL.path!)
     }
+    #endif
 
+    #if swift(>=3.0)
+    func renameJsonToSendFile() -> Bool {
+        do {
+            try fileManager.moveItem(at: entriesFileURL, to: sendingFileURL)
+            return true
+        } catch let error as NSError {
+            toNSLog("SwiftyBeaver Platform Destination could not rename json file. \(error)")
+            return false
+        }
+    }
+    #else
     func renameJsonToSendFile() -> Bool {
         do {
             try fileManager.moveItemAtURL(entriesFileURL, toURL: sendingFileURL)
@@ -347,23 +572,25 @@ public class SBPlatformDestination: BaseDestination {
             return false
         }
     }
+    #endif
 
     /// returns optional array of log dicts from a file which has 1 json string per line
-    func logsFromFile(url: NSURL) -> [[String:AnyObject]]? {
+    #if swift(>=3.0)
+    func logsFromFile(_ url: NSURL) -> [[String:AnyObject]]? {
         var lines = 0
         do {
             // try to read file, decode every JSON line and put dict from each line in array
             let fileContent = try NSString(contentsOfFile: url.path!, encoding: NSUTF8StringEncoding)
-            let linesArray = fileContent.componentsSeparatedByString("\n")
+            let linesArray = fileContent.components(separatedBy: "\n")
             var dicts = [[String: AnyObject]()] // array of dictionaries
             for lineJSON in linesArray {
                 lines += 1
                 if lineJSON.characters.first == "{" && lineJSON.characters.last == "}" {
                     // try to parse json string into dict
-                    if let data = lineJSON.dataUsingEncoding(NSUTF8StringEncoding) {
+                    if let data = lineJSON.data(using: NSUTF8StringEncoding) {
                         do {
-                            if let dict = try NSJSONSerialization.JSONObjectWithData(data,
-                                options: .MutableContainers) as? [String:AnyObject] {
+                            if let dict = try NSJSONSerialization.jsonObject(with: data,
+                                options: .mutableContainers) as? [String:AnyObject] {
                                 if !dict.isEmpty {
                                     dicts.append(dict)
                                 }
@@ -383,13 +610,67 @@ public class SBPlatformDestination: BaseDestination {
         }
         return nil
     }
+    #else
+    func logsFromFile(url: NSURL) -> [[String:AnyObject]]? {
+        var lines = 0
+        do {
+            // try to read file, decode every JSON line and put dict from each line in array
+            let fileContent = try NSString(contentsOfFile: url.path!, encoding: NSUTF8StringEncoding)
+            let linesArray = fileContent.componentsSeparatedByString("\n")
+            var dicts = [[String: AnyObject]()] // array of dictionaries
+            for lineJSON in linesArray {
+                lines += 1
+                if lineJSON.characters.first == "{" && lineJSON.characters.last == "}" {
+                    // try to parse json string into dict
+                    if let data = lineJSON.dataUsingEncoding(NSUTF8StringEncoding) {
+                        do {
+                            if let dict = try NSJSONSerialization.JSONObjectWithData(data,
+                                                                                     options: .MutableContainers) as? [String:AnyObject] {
+                                if !dict.isEmpty {
+                                    dicts.append(dict)
+                                }
+                            }
+                        } catch let error {
+                            var msg = "Error! Could not parse "
+                            msg += "line \(lines) in file \(url). \(error)"
+                            toNSLog(msg)
+                        }
+                    }
+                }
+            }
+            dicts.removeFirst()
+            return dicts
+        } catch let error {
+            toNSLog("Error! Could not read file \(url). \(error)")
+        }
+        return nil
+    }
+    #endif
+    
 
     /// returns AES-256 CBC encrypted optional string
+    #if swift(>=3.0)
+    func encrypt(_ str: String) -> String? {
+        return AES256CBC.encryptString(str, password: encryptionKey)
+    }
+    #else
     func encrypt(str: String) -> String? {
         return AES256CBC.encryptString(str, password: encryptionKey)
     }
+    #endif
 
     /// Delete file to get started again
+    #if swift(>=3.0)
+    func deleteFile(_ url: NSURL) -> Bool {
+        do {
+            try NSFileManager.default().removeItem(at: url)
+            return true
+        } catch let error {
+            toNSLog("Warning! Could not delete file \(url). \(error)")
+        }
+        return false
+    }
+    #else
     func deleteFile(url: NSURL) -> Bool {
         do {
             try NSFileManager.defaultManager().removeItemAtURL(url)
@@ -399,6 +680,7 @@ public class SBPlatformDestination: BaseDestination {
         }
         return false
     }
+    #endif
 
 
     // MARK: Device & Analytics
@@ -428,11 +710,69 @@ public class SBPlatformDestination: BaseDestination {
     }
 
     /// returns (updated) analytics dict, optionally loaded from file.
-    func analytics(url: NSURL, update: Bool = false) -> [String:AnyObject] {
+    #if swift(>=3.0)
+    func analytics(_ url: NSURL, update: Bool = false) -> [String:AnyObject] {
 
         var dict = [String:AnyObject]()
         let now = NSDate().timeIntervalSince1970
 
+        uuid =  NSUUID().uuidString
+        dict["uuid"] = uuid as AnyObject
+        dict["firstStart"] = now as AnyObject
+        dict["lastStart"] = now as AnyObject
+        dict["starts"] = 1 
+        dict["userName"] = analyticsUserName as AnyObject
+        dict["firstAppVersion"] = appVersion() as AnyObject
+        dict["appVersion"] = appVersion() as AnyObject
+        dict["firstAppBuild"] = appBuild() as AnyObject
+        dict["appBuild"] = appBuild() as AnyObject
+
+        if let loadedDict = dictFromFile(analyticsFileURL) {
+            if let val = loadedDict["firstStart"] as? Double {
+                dict["firstStart"] = val as AnyObject?
+            }
+            if let val = loadedDict["lastStart"] as? Double {
+                if update {
+                    dict["lastStart"] = now as AnyObject
+                } else {
+                    dict["lastStart"] = val as AnyObject?
+                }
+            }
+            if let val = loadedDict["starts"] as? Int {
+                if update {
+                    dict["starts"] = val + 1 as AnyObject?
+                } else {
+                    dict["starts"] = val as AnyObject?
+                }
+            }
+            if let val = loadedDict["uuid"] as? String {
+                dict["uuid"] = val as AnyObject?
+                uuid = val
+            }
+            if let val = loadedDict["userName"] as? String {
+                if update && !analyticsUserName.isEmpty {
+                    dict["userName"] = analyticsUserName as AnyObject
+                } else {
+                    if !val.isEmpty {
+                        dict["userName"] = val as AnyObject?
+                    }
+                }
+            }
+            if let val = loadedDict["firstAppVersion"] as? String {
+                dict["firstAppVersion"] = val as AnyObject?
+            }
+            if let val = loadedDict["firstAppBuild"] as? Int {
+                dict["firstAppBuild"] = val as AnyObject?
+            }
+        }
+        return dict
+    }
+    #else
+    func analytics(url: NSURL, update: Bool = false) -> [String:AnyObject] {
+        
+        var dict = [String:AnyObject]()
+        let now = NSDate().timeIntervalSince1970
+        
         uuid =  NSUUID().UUIDString
         dict["uuid"] = uuid
         dict["firstStart"] = now
@@ -443,7 +783,7 @@ public class SBPlatformDestination: BaseDestination {
         dict["appVersion"] = appVersion()
         dict["firstAppBuild"] = appBuild()
         dict["appBuild"] = appBuild()
-
+        
         if let loadedDict = dictFromFile(analyticsFileURL) {
             if let val = loadedDict["firstStart"] as? Double {
                 dict["firstStart"] = val
@@ -484,26 +824,56 @@ public class SBPlatformDestination: BaseDestination {
         }
         return dict
     }
+    #endif
 
     /// Returns the current app version string (like 1.2.5) or empty string on error
     func appVersion() -> String {
-        if let version = NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleShortVersionString") as? String {
+        #if swift(>=3.0)
+        if let version = NSBundle.main().objectForInfoDictionaryKey("CFBundleShortVersionString") as? String {
                 return version
         }
+        #else
+        if let version = NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleShortVersionString") as? String {
+            return version
+        }
+        #endif
         return ""
     }
 
     /// Returns the current app build as integer (like 563, always incrementing) or 0 on error
     func appBuild() -> Int {
+        #if swift(>=3.0)
+        if let version = NSBundle.main().infoDictionary?["CFBundleVersion"] as? String {
+            if let intVersion = Int(version) {
+                return intVersion
+            }
+        }
+        #else
         if let version = NSBundle.mainBundle().infoDictionary?["CFBundleVersion"] as? String {
             if let intVersion = Int(version) {
                 return intVersion
             }
         }
+        #endif
         return 0
     }
 
     // turns dict into JSON-encoded string
+    #if swift(>=3.0)
+    func jsonStringFromDict(_ dict: [String: AnyObject]) -> String? {
+        var jsonString: String?
+        // try to create JSON string
+        do {
+            let jsonData = try NSJSONSerialization.data(withJSONObject: dict as AnyObject, options: [])
+            if let str = NSString(data: jsonData, encoding: NSUTF8StringEncoding) as? String {
+                jsonString = str
+            }
+        } catch let error as NSError {
+            toNSLog("SwiftyBeaver Platform Destination could not create JSON from dict. \(error)")
+        }
+        return jsonString
+    }
+    #else
     func jsonStringFromDict(dict: [String: AnyObject]) -> String? {
         var jsonString: String?
         // try to create JSON string
@@ -517,17 +887,19 @@ public class SBPlatformDestination: BaseDestination {
         }
         return jsonString
     }
+    #endif
 
     /// returns optional dict from a json encoded file
-    func dictFromFile(url: NSURL) -> [String:AnyObject]? {
+    #if swift(>=3.0)
+    func dictFromFile(_ url: NSURL) -> [String:AnyObject]? {
         do {
             // try to read file, decode every JSON line and put dict from each line in array
             let fileContent = try NSString(contentsOfFile: url.path!, encoding: NSUTF8StringEncoding)
             // try to parse json string into dict
-            if let data = fileContent.dataUsingEncoding(NSUTF8StringEncoding) {
+            if let data = fileContent.data(using: NSUTF8StringEncoding) {
                 do {
-                    return try NSJSONSerialization.JSONObjectWithData(data,
-                        options: .MutableContainers) as? [String:AnyObject]
+                    return try NSJSONSerialization.jsonObject(with: data,
+                        options: .mutableContainers) as? [String:AnyObject]
                 } catch let error {
                     toNSLog("SwiftyBeaver Platform Destination could not parse file \(url). \(error)")
                 }
@@ -537,9 +909,30 @@ public class SBPlatformDestination: BaseDestination {
         }
         return nil
     }
+    #else
+    func dictFromFile(url: NSURL) -> [String:AnyObject]? {
+        do {
+            // try to read file, decode every JSON line and put dict from each line in array
+            let fileContent = try NSString(contentsOfFile: url.path!, encoding: NSUTF8StringEncoding)
+            // try to parse json string into dict
+            if let data = fileContent.dataUsingEncoding(NSUTF8StringEncoding) {
+                do {
+                    return try NSJSONSerialization.JSONObjectWithData(data,
+                                                                      options: .MutableContainers) as? [String:AnyObject]
+                } catch let error {
+                    toNSLog("SwiftyBeaver Platform Destination could not parse file \(url). \(error)")
+                }
+            }
+        } catch let error {
+            toNSLog("SwiftyBeaver Platform Destination could not read file \(url). \(error)")
+        }
+        return nil
+    }
+    #endif
 
     // turns dict into JSON and saves it to file
-    func saveDictToFile(dict: [String: AnyObject], url: NSURL) -> Bool {
+    #if swift(>=3.0)
+    func saveDictToFile(_ dict: [String: AnyObject], url: NSURL) -> Bool {
         let jsonString = jsonStringFromDict(dict)
 
         if let str = jsonString {
@@ -548,18 +941,43 @@ public class SBPlatformDestination: BaseDestination {
         }
         return false
     }
+    #else
+    func saveDictToFile(dict: [String: AnyObject], url: NSURL) -> Bool {
+        let jsonString = jsonStringFromDict(dict)
+        
+        if let str = jsonString {
+            toNSLog("saving '\(str)' to \(url)")
+            return saveToFile(str, url: url, overwrite: true)
+        }
+        return false
+    }
+    #endif
+    
+
 
 
     // MARK: Debug Helpers
 
     /// log String to toNSLog. Used to debug the class logic
+    #if swift(>=3.0)
+    func toNSLog(_ str: String) {
+        if showNSLog {
+            NSLog("SBPlatform: \(str)")
+        }
+    }
+    #else
     func toNSLog(str: String) {
         if showNSLog {
             NSLog("SBPlatform: \(str)")
         }
     }
+    #endif
 
     /// helper function for thread logging during development
+    #if swift(>=3.0)
+    // Swift 3 Semantic Change. 
+    // This function is already available as the class function SwiftyBeaver.threadName()
+    #else
     func threadName() -> String {
         if NSThread.isMainThread() {
             return "main"
@@ -574,4 +992,5 @@ public class SBPlatformDestination: BaseDestination {
             }
         }
     }
+    #endif
 }

--- a/sources/SwiftyBeaver.swift
+++ b/sources/SwiftyBeaver.swift
@@ -30,6 +30,15 @@ public class SwiftyBeaver {
     // MARK: Destination Handling
 
     /// returns boolean about success
+    #if swift(>=3.0)
+    public class func addDestination(_ destination: BaseDestination) -> Bool {
+        if destinations.contains(destination) {
+            return false
+        }
+        destinations.insert(destination)
+        return true
+    }
+    #else
     public class func addDestination(destination: BaseDestination) -> Bool {
         if destinations.contains(destination) {
             return false
@@ -37,8 +46,18 @@ public class SwiftyBeaver {
         destinations.insert(destination)
         return true
     }
+    #endif
 
     /// returns boolean about success
+    #if swift(>=3.0)
+    public class func removeDestination(_ destination: BaseDestination) -> Bool {
+        if destinations.contains(destination) == false {
+            return false
+        }
+        destinations.remove(destination)
+        return true
+    }
+    #else
     public class func removeDestination(destination: BaseDestination) -> Bool {
         if destinations.contains(destination) == false {
             return false
@@ -46,6 +65,9 @@ public class SwiftyBeaver {
         destinations.remove(destination)
         return true
     }
+    #endif
+
+
 
     /// if you need to start fresh
     public class func removeAllDestinations() {
@@ -62,7 +84,19 @@ public class SwiftyBeaver {
         if NSThread.isMainThread() {
             return ""
         } else {
-            if let threadName = NSThread.currentThread().name where !threadName.isEmpty {
+            #if swift(>=3.0)
+            let threadName = NSThread.current().name
+            if let threadName = threadName where !threadName.isEmpty {
+                return threadName
+            } else if let queueName = NSString(utf8String:
+                dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL)) as String? where !queueName.isEmpty {
+                return queueName
+            } else {
+                return String(format: "%p", NSThread.current())
+            }
+            #else
+            let threadName = NSThread.currentThread().name
+            if let threadName = threadName where !threadName.isEmpty {
                 return threadName
             } else if let queueName = String(UTF8String:
                 dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL)) where !queueName.isEmpty {
@@ -70,43 +104,83 @@ public class SwiftyBeaver {
             } else {
                 return String(format: "%p", NSThread.currentThread())
             }
+            #endif
+
         }
     }
 
     // MARK: Levels
 
     /// log something generally unimportant (lowest priority)
+    #if swift(>=3.0)
+    public class func verbose(_ message: @autoclosure () -> Any, _
+        path: String = #file, _ function: String = #function, line: Int = #line) {
+        dispatch_send(level: Level.Verbose, message: message, thread: threadName(), path: path, function: function, line: line)
+    }
+    #else
     public class func verbose(@autoclosure message: () -> Any, _
         path: String = #file, _ function: String = #function, line: Int = #line) {
         dispatch_send(Level.Verbose, message: message, thread: threadName(), path: path, function: function, line: line)
     }
+    #endif
 
     /// log something which help during debugging (low priority)
+    #if swift(>=3.0)
+    public class func debug(_ message: @autoclosure () -> Any, _
+        path: String = #file, _ function: String = #function, line: Int = #line) {
+        dispatch_send(level: Level.Debug, message: message, thread: threadName(), path: path, function: function, line: line)
+    }
+    #else
     public class func debug(@autoclosure message: () -> Any, _
         path: String = #file, _ function: String = #function, line: Int = #line) {
         dispatch_send(Level.Debug, message: message, thread: threadName(), path: path, function: function, line: line)
     }
+    #endif
+
+
 
     /// log something which you are really interested but which is not an issue or error (normal priority)
+    #if swift(>=3.0)
+    public class func info(_ message: @autoclosure () -> Any, _
+        path: String = #file, _ function: String = #function, line: Int = #line) {
+        dispatch_send(level: Level.Info, message: message, thread: threadName(), path: path, function: function, line: line)
+    }
+    #else
     public class func info(@autoclosure message: () -> Any, _
         path: String = #file, _ function: String = #function, line: Int = #line) {
         dispatch_send(Level.Info, message: message, thread: threadName(), path: path, function: function, line: line)
     }
+    #endif
 
     /// log something which may cause big trouble soon (high priority)
+    #if swift(>=3.0)
+    public class func warning(_ message: @autoclosure () -> Any, _
+        path: String = #file, _ function: String = #function, line: Int = #line) {
+        dispatch_send(level: Level.Warning, message: message, thread: threadName(), path: path, function: function, line: line)
+    }
+    #else
     public class func warning(@autoclosure message: () -> Any, _
         path: String = #file, _ function: String = #function, line: Int = #line) {
         dispatch_send(Level.Warning, message: message, thread: threadName(), path: path, function: function, line: line)
     }
+    #endif
 
     /// log something which will keep you awake at night (highest priority)
+    #if swift(>=3.0)
+    public class func error(_ message: @autoclosure () -> Any, _
+        path: String = #file, _ function: String = #function, line: Int = #line) {
+        dispatch_send(level: Level.Error, message: message, thread: threadName(), path: path, function: function, line: line)
+    }
+    #else
     public class func error(@autoclosure message: () -> Any, _
         path: String = #file, _ function: String = #function, line: Int = #line) {
         dispatch_send(Level.Error, message: message, thread: threadName(), path: path, function: function, line: line)
     }
+    #endif
 
     /// internal helper which dispatches send to dedicated queue if minLevel is ok
-    class func dispatch_send(level: SwiftyBeaver.Level, @autoclosure message: () -> Any,
+    #if swift(>=3.0)
+    class func dispatch_send(level: SwiftyBeaver.Level, message: @autoclosure () -> Any,
         thread: String, path: String, function: String, line: Int) {
         for dest in destinations {
 
@@ -130,25 +204,71 @@ public class SwiftyBeaver {
             }
         }
     }
-
-  /**
-   Flush all destinations to make sure all logging messages have been written out
-   Returns after all messages flushed or timeout seconds
-
-   - returns: true if all messages flushed, false if timeout occurred
-   */
-  public class func flush(secondTimeout: Int64) -> Bool {
-    let grp = dispatch_group_create()
-    for dest in destinations {
-      if let queue = dest.queue {
-        dispatch_group_enter(grp)
-        dispatch_async(queue, {
-          dest.flush()
-          dispatch_group_leave(grp)
-        })
-      }
+    #else
+    class func dispatch_send(level: SwiftyBeaver.Level, @autoclosure message: () -> Any,
+        thread: String, path: String, function: String, line: Int) {
+        for dest in destinations {
+            
+            guard let queue = dest.queue else {
+                continue
+            }
+            
+            if dest.shouldLevelBeLogged(level, path: path, function: function) {
+                // try to convert msg object to String and put it on queue
+                let msgStr = "\(message())"
+                
+                if dest.asynchronously {
+                    dispatch_async(queue) {
+                        dest.send(level, msg: msgStr, thread: thread, path: path, function: function, line: line)
+                    }
+                } else {
+                    dispatch_sync(queue) {
+                        dest.send(level, msg: msgStr, thread: thread, path: path, function: function, line: line)
+                    }
+                }
+            }
+        }
     }
-    let waitUntil = dispatch_time(DISPATCH_TIME_NOW, secondTimeout * 1000000000)
-    return dispatch_group_wait(grp, waitUntil) == 0
-  }
+    #endif
+
+    /**
+    Flush all destinations to make sure all logging messages have been written out
+    Returns after all messages flushed or timeout seconds
+
+    - returns: true if all messages flushed, false if timeout occurred
+    */
+    #if swift(>=3.0)
+    public class func flush(_ secondTimeout: Int64) -> Bool {
+        guard let grp = dispatch_group_create() else {
+            return false // Swift 3 semantic change. Should perhaps throw.
+        }
+        for dest in destinations {
+            if let queue = dest.queue {
+                dispatch_group_enter(grp)
+                dispatch_async(queue, {
+                    dest.flush()
+                    dispatch_group_leave(grp)
+                })
+            }
+        }
+        let waitUntil = dispatch_time(DISPATCH_TIME_NOW, secondTimeout * 1000000000)
+        return dispatch_group_wait(grp, waitUntil) == 0
+    }
+    #else
+    public class func flush(secondTimeout: Int64) -> Bool {
+        let grp = dispatch_group_create()
+        for dest in destinations {
+            if let queue = dest.queue {
+                dispatch_group_enter(grp)
+                dispatch_async(queue, {
+                    dest.flush()
+                    dispatch_group_leave(grp)
+                })
+            }
+        }
+        let waitUntil = dispatch_time(DISPATCH_TIME_NOW, secondTimeout * 1000000000)
+        return dispatch_group_wait(grp, waitUntil) == 0
+    }
+    #endif
+
 }


### PR DESCRIPTION
This version builds and passes tests on both Swift 3 DEVELOPMENT-SNAPSHOT-2016-05-09 and Swift 2.2.

Please be aware of the potential maintenance implications.

In Swift 3, by the first parameter is no longer removed by default and, unfortunately, you can’t #if #endif out just the function declaration, you have to do the entire function. From SE-0020, "Like other build configurations, #if swift isn't line-based - it encloses whole statements or declarations."


Given this, I erred on the side of maintaining your current public APIs, however since the philosophy of the first parameter has changed in Swift 3, you’ll probably want to look into updating the API.

As an example,
`class func encryptString(_ str: String, password: String) -> String? {`
would probably become
`class func encrypt(string: String, password: String) -> String? {`
in Swift 3.

So basically, the downside of the way that we can achieve compatibility is some functions are duplicated. Although, the syntax changes in Swift 3 are pretty far-reaching, so a number of the function bodies would have to change anyway.

Also please note, I've marked semantics changes with // Swift 3 Semantic Change.