### PR TITLE
Fix memory leak in formattedMessage on string interpolation

### DIFF
--- a/sources/BaseDestination.swift
+++ b/sources/BaseDestination.swift
@@ -186,8 +186,6 @@ public class BaseDestination: Hashable, Equatable {
     /// returns the formatted log message
     func formattedMessage(dateString: String, levelString: String, msg: String,
         thread: String, path: String, function: String, line: Int, detailOutput: Bool) -> String {
-        // just use the file name of the path and remove suffix
-        let file = path.componentsSeparatedByString("/").last!.componentsSeparatedByString(".").first!
         var str = ""
         if dateString != "" {
              str += "[\(dateString)] "
@@ -197,7 +195,9 @@ public class BaseDestination: Hashable, Equatable {
                 str += "|\(thread)| "
             }
 
-            str += "\(file).\(function):\(line) \(levelString): \(msg)"
+            // just use the file name of the path and remove suffix
+            let file = path.componentsSeparatedByString("/").last!.componentsSeparatedByString(".").first!
+            str += "\(file).\(function):\(String(line)) \(levelString): \(msg)"
         } else {
             str += "\(levelString): \(msg)"
         }


### PR DESCRIPTION
![leak](https://cloud.githubusercontent.com/assets/669244/15391488/117ebbc6-1dca-11e6-96ce-f7467cbeeccf.png)

Don't know why but changing `\(line)` to `\(String(line))` fixes a leak.
