### PR TITLE
Add content filtering

### DIFF
--- a/ContentFilter.swift
+++ b/ContentFilter.swift
@@ -1,0 +1,115 @@
+//
+//  ContentFilter.swift
+//  SwiftyBeaver
+//
+// Created by Jeff Roberts on 5/30/16.
+// Copyright (c) 2016 Sebastian Kreutzberger. All rights reserved.
+//  Some rights reserved: http://opensource.org/licenses/MIT
+//
+
+import Foundation
+
+public protocol ContentFilter : class {
+    func apply(message : String) -> Bool
+}
+
+//
+// BasicContentFilter is a ContentFilter that can filter based upon whether the logged
+// messages beginsWith, contains or endsWith a collection of Strings. You can specify
+// any combination of beginsWith, contains or endsWith and the filter will answer true
+// if ANY of the values match. The comparison is case sensitive so "hello" does not match "Hello"
+// or "heLLO". It is additive, so you can invoke one of the functions multiple times and the
+// speccified values will be accumulated.
+//
+// Example:
+// let filter = BasicContentFilter()
+// filter.beginsWith("abc", "def")
+// filter.beginsWith("xyz", "123")
+//
+// This will result in a BasicContentFilter that will check if the message to be logged
+// beginsWith "abc" or "def" or "xyz" or "123".
+//
+// You can combine the beginsWith with any combination of contains and/or endsWith.
+//
+// Example:
+// // let filter = BasicContentFilter()
+// filter.beginsWith("abc", "def")
+// filter.contains("xyz", "123")
+// filter.endsWith("321")
+//
+// This will result in a BasicContentFilter that will check if the message to be logged
+// beginsWith "abc or "def" or contains "xyz" or "123" or endsWith "321".
+//
+// The BasicContentFilter API is fluent, meaning that invoking beginsWith, contains or
+// endsWith returns self allowing you to fluently call other API functions.
+//
+// Example (fluent API)
+// let filter = BasicContentFilter()
+// filter.beginsWith("abc")
+//      .contains("123")
+//      .endsWith("abc123")
+//
+public class BasicContentFilter : ContentFilter {
+    var beginsWith : [String]?
+    var contains : [String]?
+    var endsWith: [String]?
+
+    public init() {}
+
+    public func beginsWith(strings : String...) -> BasicContentFilter {
+        if beginsWith == nil {
+            beginsWith = []
+        }
+
+        strings.forEach {
+            string in
+            beginsWith?.append(string)
+        }
+
+        return self
+    }
+
+    public func contains(strings : String...) -> BasicContentFilter {
+        if contains == nil {
+            contains = []
+        }
+
+        strings.forEach {
+            string in
+            contains?.append(string)
+        }
+
+        return self
+    }
+
+    public func endsWith(strings : String...) -> BasicContentFilter {
+        if endsWith == nil {
+            endsWith = []
+        }
+
+        strings.forEach {
+            string in
+            endsWith?.append(string)
+        }
+
+        return self
+    }
+
+    // ContentFilter
+    public func apply(message : String) -> Bool {
+        guard beginsWith != nil || contains != nil || endsWith != nil else {
+            return true
+        }
+
+        return beginsWith?.filter {
+            prefix in
+            return message.hasPrefix(prefix)
+        }.count > 0 || contains?.filter {
+            string in
+            return message.containsString(string)
+        }.count > 0 || endsWith?.filter {
+            suffix in
+            return message.hasSuffix(suffix)
+        }.count > 0
+    }
+}

--- a/SwiftyBeaver.xcodeproj/project.pbxproj
+++ b/SwiftyBeaver.xcodeproj/project.pbxproj
@@ -8,6 +8,11 @@
 
 /* Begin PBXBuildFile section */
 		048E6BFA1CDBB68E00DC9116 /* DestinationSetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048E6BF91CDBB68E00DC9116 /* DestinationSetTests.swift */; };
+		54C181C51C6F5107D7ACBE32 /* ContentFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C180F8EDF999E1FA803EFE /* ContentFilter.swift */; };
+		54C18773C7BE7A309752FF80 /* ContentFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C180F8EDF999E1FA803EFE /* ContentFilter.swift */; };
+		54C187B0E53CB115294803A5 /* ContentFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C180F8EDF999E1FA803EFE /* ContentFilter.swift */; };
+		54C18A90430CA3795054F8FA /* BasicContentFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C182FE087D8EB950376A8C /* BasicContentFilterTests.swift */; };
+		54C18F9DD9370415D62D3418 /* ContentFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C180F8EDF999E1FA803EFE /* ContentFilter.swift */; };
 		9E195B0A1C6B3B4600D924CB /* AES256CBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E195B091C6B3B4600D924CB /* AES256CBC.swift */; };
 		9E195B0B1C6B3B4600D924CB /* AES256CBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E195B091C6B3B4600D924CB /* AES256CBC.swift */; };
 		9E195B0C1C6B3B4600D924CB /* AES256CBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E195B091C6B3B4600D924CB /* AES256CBC.swift */; };
@@ -60,6 +65,8 @@
 
 /* Begin PBXFileReference section */
 		048E6BF91CDBB68E00DC9116 /* DestinationSetTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DestinationSetTests.swift; sourceTree = "<group>"; };
+		54C180F8EDF999E1FA803EFE /* ContentFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentFilter.swift; sourceTree = "<group>"; };
+		54C182FE087D8EB950376A8C /* BasicContentFilterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasicContentFilterTests.swift; sourceTree = "<group>"; };
 		9E195B091C6B3B4600D924CB /* AES256CBC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AES256CBC.swift; path = sources/AES256CBC.swift; sourceTree = "<group>"; };
 		9E195B0E1C6B3B6F00D924CB /* AES256CBCTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AES256CBCTests.swift; sourceTree = "<group>"; };
 		9E195B101C6B766D00D924CB /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -135,6 +142,7 @@
 				9E31D62D1C185EE3004E0980 /* FileDestination.swift */,
 				9ED096F71C521C6900FE3059 /* SBPlatformDestination.swift */,
 				9E31D6281C185ECD004E0980 /* SwiftyBeaver.swift */,
+				54C180F8EDF999E1FA803EFE /* ContentFilter.swift */,
 			);
 			name = sources;
 			sourceTree = "<group>";
@@ -177,6 +185,7 @@
 				9EA53F881C561E4C00B160AF /* Secrets.swift */,
 				9EA53F8A1C561EE600B160AF /* SecretsExample.swift */,
 				048E6BF91CDBB68E00DC9116 /* DestinationSetTests.swift */,
+				54C182FE087D8EB950376A8C /* BasicContentFilterTests.swift */,
 			);
 			path = SwiftyBeaverTests;
 			sourceTree = "<group>";
@@ -418,6 +427,7 @@
 				9E31D6301C185EE3004E0980 /* FileDestination.swift in Sources */,
 				9E195B0A1C6B3B4600D924CB /* AES256CBC.swift in Sources */,
 				9E31D62E1C185EE3004E0980 /* BaseDestination.swift in Sources */,
+				54C181C51C6F5107D7ACBE32 /* ContentFilter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -431,6 +441,7 @@
 				048E6BFA1CDBB68E00DC9116 /* DestinationSetTests.swift in Sources */,
 				9E195B0F1C6B3B6F00D924CB /* AES256CBCTests.swift in Sources */,
 				9E6CA9FC1C12BA7A009D9093 /* BaseDestinationTests.swift in Sources */,
+				54C18A90430CA3795054F8FA /* BasicContentFilterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -444,6 +455,7 @@
 				ACE597791C1882DF0031451F /* FileDestination.swift in Sources */,
 				9E195B0B1C6B3B4600D924CB /* AES256CBC.swift in Sources */,
 				ACE5977A1C1882DF0031451F /* BaseDestination.swift in Sources */,
+				54C187B0E53CB115294803A5 /* ContentFilter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -457,6 +469,7 @@
 				ACE5978A1C18830D0031451F /* FileDestination.swift in Sources */,
 				9E195B0C1C6B3B4600D924CB /* AES256CBC.swift in Sources */,
 				ACE5978B1C18830D0031451F /* BaseDestination.swift in Sources */,
+				54C18773C7BE7A309752FF80 /* ContentFilter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -470,6 +483,7 @@
 				ACE5979B1C18832E0031451F /* FileDestination.swift in Sources */,
 				9E195B0D1C6B3B4600D924CB /* AES256CBC.swift in Sources */,
 				ACE5979C1C18832E0031451F /* BaseDestination.swift in Sources */,
+				54C18F9DD9370415D62D3418 /* ContentFilter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftyBeaverTests/BaseDestinationTests.swift
+++ b/SwiftyBeaverTests/BaseDestinationTests.swift
@@ -150,4 +150,76 @@ class BaseDestinationTests: XCTestCase {
         // check filter 5 (function)
         XCTAssertTrue(obj.shouldLevelBeLogged(SwiftyBeaver.Level.Verbose, path: "", function: "MyFunction"))
     }
+
+    func test_applyContentFilters_noContentFilters_answersTrue() {
+        let destination = BaseDestination()
+
+        XCTAssertTrue(destination.applyContentFilters("Some message"))
+    }
+
+    func test_applyContentFilters_oneContentFilterThatAnswersTrue_answersTrue() {
+        let filter = BasicContentFilter()
+        filter.beginsWith("Some")
+
+        let destination = BaseDestination()
+        destination.addContentFilter(filter)
+
+        XCTAssertTrue(destination.applyContentFilters("Some message"))
+    }
+
+    func test_applyContentFilters_oneContentFilterThatAnswersFalse_answersFalse() {
+        let filter = BasicContentFilter()
+        filter.beginsWith("One")
+
+        let destination = BaseDestination()
+        destination.addContentFilter(filter)
+
+        XCTAssertFalse(destination.applyContentFilters("Some message"))
+    }
+
+    func test_applyContentFilters_multipleContentFiltersOneThatAnswersTrue_answersTrue() {
+        let destination = BaseDestination()
+
+        var filter = BasicContentFilter()
+        filter.beginsWith("One")
+        destination.addContentFilter(filter)
+
+        filter = BasicContentFilter()
+        filter.contains("Some")
+        destination.addContentFilter(filter)
+
+        XCTAssertTrue(destination.applyContentFilters("Some message"))
+    }
+
+    func test_applyContentFilters_multipleContentFiltersNoneThatAnswersTrue_answersFalse() {
+        let destination = BaseDestination()
+
+        var filter = BasicContentFilter()
+        filter.beginsWith("One")
+        destination.addContentFilter(filter)
+
+        filter = BasicContentFilter()
+        filter.endsWith("Some")
+        destination.addContentFilter(filter)
+
+        XCTAssertFalse(destination.applyContentFilters("Some message"))
+    }
+
+    func test_addContentFilter_contentFilterCountIsCorrect() {
+        let destination = BaseDestination()
+        destination.addContentFilter(BasicContentFilter())
+
+        XCTAssertEqual(destination.contentFilters.count, 1)
+    }
+
+    func test_rmoveContentFilter_contentFilterCountIsCorrect() {
+        let destination = BaseDestination()
+
+        destination.addContentFilter(BasicContentFilter())
+        let filter = BasicContentFilter()
+        destination.addContentFilter(filter)
+        destination.removeContentFilter(filter)
+
+        XCTAssertEqual(destination.contentFilters.count, 1)
+    }
 }

--- a/SwiftyBeaverTests/BasicContentFilterTests.swift
+++ b/SwiftyBeaverTests/BasicContentFilterTests.swift
@@ -1,0 +1,92 @@
+//
+// Created by Jeff Roberts on 5/30/16.
+// Copyright (c) 2016 Sebastian Kreutzberger. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import SwiftyBeaver
+
+class BasicContentFilterTests : XCTestCase {
+    private var contentFilter : BasicContentFilter!
+
+    override func setUp() {
+        super.setUp()
+        contentFilter = BasicContentFilter()
+    }
+
+    func test_apply_noComparisonCriteria_answersTrue() {
+        XCTAssertTrue(contentFilter.apply("Some simple message"))
+    }
+
+    func test_apply_oneBeginsWithThatMatches_answersTrue() {
+        contentFilter?.beginsWith("Some")
+        XCTAssertTrue(contentFilter.apply("Some simple message"))
+    }
+
+    func test_apply_oneBeginsWithThatDoesNotMatch_answersFalse() {
+        contentFilter?.beginsWith("some")
+        XCTAssertFalse(contentFilter.apply("Some simple message"))
+    }
+
+    func test_apply_multipleBeginsWithThatDoesNotMatch_answersFalse() {
+        contentFilter?.beginsWith("one", "two", "three")
+        XCTAssertFalse(contentFilter.apply("Some simple message"))
+    }
+
+    func test_apply_multipleBeginsWithThatMatches_answersTrue() {
+        contentFilter?.beginsWith("some", "one", "two", "three", "Some")
+        XCTAssertTrue(contentFilter.apply("Some simple message"))
+    }
+
+    func test_apply_oneContainsThatMatches_answersTrue() {
+        contentFilter?.contains("simple")
+        XCTAssertTrue(contentFilter.apply("Some simple message"))
+    }
+
+    func test_apply_oneContainsThatDoesNotMatch_answersFalse() {
+        contentFilter?.contains("complex")
+        XCTAssertFalse(contentFilter.apply("Some simple message"))
+    }
+
+    func test_apply_multipleContainsThatDoesNotMatch_answersFalse() {
+        contentFilter?.contains("complex", "very complex", "not simple")
+        XCTAssertFalse(contentFilter.apply("Some simple message"))
+    }
+
+    func test_apply_multipleContainsThatMatches_answersTrue() {
+        contentFilter?.contains("complex", "very complex", "not simple", "Simple", "simple")
+        XCTAssertTrue(contentFilter.apply("Some simple message"))
+    }
+
+    func test_apply_oneEndsWithThatMatches_answersTrue() {
+        contentFilter?.endsWith("message")
+        XCTAssertTrue(contentFilter.apply("Some simple message"))
+    }
+
+    func test_apply_oneEndsWithThatDoesNotMatch_answersFalse() {
+        contentFilter?.endsWith("massage")
+        XCTAssertFalse(contentFilter.apply("Some simple message"))
+    }
+
+    func test_apply_multipleEndsWithThatDoesNotMatch_answersFalse() {
+        contentFilter?.endsWith("text message", "phone message", "Message", "messages")
+        XCTAssertFalse(contentFilter.apply("Some simple message"))
+    }
+
+    func test_apply_multipleEndsWithThatMatches_answersTrue() {
+        contentFilter?.endsWith("text message", "phone message", "Message", "messages", "message")
+        XCTAssertTrue(contentFilter.apply("Some simple message"))
+    }
+
+    func test_apply_oneOfEach_noneOfWhichMatch_answersFalse() {
+        contentFilter?.endsWith("hello").contains("world").endsWith("goodbye")
+        XCTAssertFalse(contentFilter.apply("Some simple message"))
+    }
+
+    func test_apply_oneOfEach_oneOfWhichMatches_answersTrue() {
+        contentFilter?.endsWith("hello").contains("world").endsWith("message")
+        XCTAssertTrue(contentFilter.apply("Some simple message"))
+    }
+
+}

--- a/sources/BaseDestination.swift
+++ b/sources/BaseDestination.swift
@@ -69,6 +69,7 @@ public class BaseDestination: Hashable, Equatable {
     }
 
     var minLevelFilters = [MinLevelFilter]()
+    var contentFilters = [ContentFilter]()
     let formatter = NSDateFormatter()
 
     var reset = "\u{001b}[;"
@@ -92,6 +93,35 @@ public class BaseDestination: Hashable, Equatable {
     public func addMinLevelFilter(minLevel: SwiftyBeaver.Level, path: String, function: String = "") {
         let filter = MinLevelFilter(minLevel: minLevel, path: path, function: function)
         minLevelFilters.append(filter)
+    }
+
+    // Apply the ContentFilters to the proposed logged message. If ANY of the filters answer true, the message will be logged.
+    public func applyContentFilters(message : String) -> Bool {
+        guard contentFilters.count > 0 else {
+            return true
+        }
+
+        return contentFilters.filter {
+            contentFilter in
+
+            return contentFilter.apply(message)
+        }.count > 0
+    }
+
+    /// Add a ContentFilter to this destination. When multiple filters exist, a message will be logged if any of the ContentFilters answers true
+    public func addContentFilter(contentFilter : ContentFilter) {
+        contentFilters.append(contentFilter)
+    }
+
+    /// Remove a ContentFilter from this destination.
+    public func removeContentFilter(contentFilter : ContentFilter) {
+        guard let index = contentFilters.indexOf({
+            return $0 === contentFilter
+        }) else {
+            return
+        }
+
+        contentFilters.removeAtIndex(index)
     }
 
     /// send / store the formatted log message to the destination

--- a/sources/SwiftyBeaver.swift
+++ b/sources/SwiftyBeaver.swift
@@ -119,6 +119,10 @@ public class SwiftyBeaver {
                 let msgStr = "\(message())"
                 let f = stripParams(function)
 
+                guard dest.applyContentFilters(msgStr) else {
+                    continue
+                }
+
                 if dest.asynchronously {
                     dispatch_async(queue) {
                         dest.send(level, msg: msgStr, thread: thread, path: path, function: f, line: line)


### PR DESCRIPTION
This PR allows Content Filters to be added to a destination to further
control what gets sent to the destination. A ContentFilter, when applied, answers
true or false. Answering true allows the message to be logged. If multiple content
filters have been added to a destination, ANY filter answering true will allow the message
to be logged even if others answer false.