### PR TITLE
Update to Swift 2.3

### DIFF
--- a/SwiftyBeaver.xcodeproj/project.pbxproj
+++ b/SwiftyBeaver.xcodeproj/project.pbxproj
@@ -540,6 +540,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 				VALID_ARCHS = "arm64 armv7 armv7s x86_64";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -581,6 +582,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				ONLY_ACTIVE_ARCH = NO;
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 2.3;
 				VALIDATE_PRODUCT = YES;
 				VALID_ARCHS = "arm64 armv7 armv7s x86_64";
 				VERSIONING_SYSTEM = "apple-generic";

--- a/sources/SBPlatformDestination.swift
+++ b/sources/SBPlatformDestination.swift
@@ -114,9 +114,16 @@ public class SBPlatformDestination: BaseDestination {
         }
 
         if let baseURL = baseURL {
-            entriesFileURL = baseURL.URLByAppendingPathComponent("sbplatform_entries.json", isDirectory: false)
-            sendingFileURL = baseURL.URLByAppendingPathComponent("sbplatform_entries_sending.json", isDirectory: false)
-            analyticsFileURL = baseURL.URLByAppendingPathComponent("sbplatform_analytics.json", isDirectory: false)
+            if let entriesFileURL = baseURL.URLByAppendingPathComponent("sbplatform_entries.json", isDirectory: false),
+                sendingFileURL = baseURL.URLByAppendingPathComponent("sbplatform_entries_sending.json", isDirectory: false),
+                analyticsFileURL = baseURL.URLByAppendingPathComponent("sbplatform_analytics.json", isDirectory: false) {
+                self.entriesFileURL = entriesFileURL
+                self.sendingFileURL = sendingFileURL
+                self.analyticsFileURL = analyticsFileURL
+            } else {
+                // it is too early in the class lifetime to be able to use toNSLog()
+                print("Warning! Could not set URLs.")
+            }
 
             // get, update loaded and save analytics data to file on start
             let dict = analytics(analyticsFileURL, update: true)


### PR DESCRIPTION
I followed the pattern in the `swift3` branch for dealing with the optional returning `URLByAppendingPathComponent`.

This is a breaking change for Swift 2.2, so you might want to wrap it in `#swift` checks, and/or simply have a Swift 2.3 branch (since it's not released yet anyway).