### PR TITLE
Use a format specifier for NSLog statement

### DIFF
--- a/sources/ConsoleDestination.swift
+++ b/sources/ConsoleDestination.swift
@@ -26,7 +26,7 @@ public class ConsoleDestination: BaseDestination {
 
         if let str = formattedString {
             if useNSLog {
-                NSLog(str)
+                NSLog("%@", str)
             } else {
                 print(str)
             }


### PR DESCRIPTION
First argument to `NSLog` is a format specifier. We shouldn't pass a user specified string directly to the format specifier argument (security issue, can crash).