### PR TITLE
Xcode 8 Beta 3 warning fix

### DIFF
--- a/sources/SBPlatformDestination.swift
+++ b/sources/SBPlatformDestination.swift
@@ -20,7 +20,7 @@ import Foundation
             uname(&systemInfo)
             let machineMirror = Mirror(reflecting: systemInfo.machine)
             let identifier = machineMirror.children.reduce("") { identifier, element in
-                guard let value = element.value as? Int8 where value != 0 else { return identifier }
+                guard let value = element.value as? Int8, value != 0 else { return identifier }
                 return identifier + String(UnicodeScalar(UInt8(value)))
             }
             return identifier
@@ -598,7 +598,7 @@ public class SBPlatformDestination: BaseDestination {
         if Thread.isMainThread {
             return "main"
         } else {
-            if let threadName = Thread.current.name where !threadName.isEmpty {
+            if let threadName = Thread.current.name, !threadName.isEmpty {
                 return threadName
             } else {
                 return String(format: "%p", Thread.current)

--- a/sources/SwiftyBeaver.swift
+++ b/sources/SwiftyBeaver.swift
@@ -63,7 +63,7 @@ public class SwiftyBeaver {
             return ""
         } else {
             let threadName = Thread.current.name
-            if let threadName = threadName where !threadName.isEmpty {
+            if let threadName = threadName, !threadName.isEmpty {
                 return threadName
             } else {
                 return String(format: "%p", Thread.current)


### PR DESCRIPTION
This PR fixes the warning Xcode 8 Beta 3 emits in regards to `where` clauses being removed from Swift 3 and replaced by using a single `,` as per [`SE-0099`](https://github.com/apple/swift-evolution/blob/master/proposals/0099-conditionclauses.md)