### PR TITLE
set OS X target to 10.10

### DIFF
--- a/SwiftyBeaver.xcodeproj/project.pbxproj
+++ b/SwiftyBeaver.xcodeproj/project.pbxproj
@@ -757,6 +757,7 @@
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.SwiftyBeaver.SwiftyBeaver;
 				PRODUCT_NAME = SwiftyBeaver;
 				SDKROOT = macosx;
@@ -779,6 +780,7 @@
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.SwiftyBeaver.SwiftyBeaver;
 				PRODUCT_NAME = SwiftyBeaver;
 				SDKROOT = macosx;


### PR DESCRIPTION
Previously, the value was empty and building with Carthage resulted in the most recent 10.11 SDK to be required.