### PR TITLE
Support running on Apple TV hardware

### DIFF
--- a/sources/SBPlatformDestination.swift
+++ b/sources/SBPlatformDestination.swift
@@ -108,8 +108,10 @@ public class SBPlatformDestination: BaseDestination {
                 }
             }
         } else {
+            let path: NSSearchPathDirectory = OS == "tvOS" ? .CachesDirectory : .DocumentDirectory
+    
             // iOS, watchOS, etc. are using the document directory of the app
-            if let url = fileManager.URLsForDirectory(.DocumentDirectory, inDomains: .UserDomainMask).first {
+            if let url = fileManager.URLsForDirectory(path, inDomains: .UserDomainMask).first {
                 baseURL = url
             }
         }


### PR DESCRIPTION
The "Documents" folder does not exist on Apple TV hardware and so at the moment the framework fails to initialise.   

An Apple TV app can only store data in the UserDefaults, Cloud or Cache folder - see
https://developer.apple.com/library/prerelease/content/documentation/General/Conceptual/AppleTV_PG/


As such the framework needs to initialise using the Cache folder during startup rather then the Documents - just for tvOS..

