### PR TITLE
Bug fix for letting filters work with right minLevels

### DIFF
--- a/SwiftyBeaverTests/BaseDestinationTests.swift
+++ b/SwiftyBeaverTests/BaseDestinationTests.swift
@@ -349,13 +349,13 @@ class BaseDestinationTests: XCTestCase {
             function: "myFunc",
             message: "Hello World"))
 
-        // not in filter but matching global minLevel
-        XCTAssertFalse(destination.shouldLevelBeLogged(.Info,
+        // Test minLevel < log level, to make sure excludes file isn't applied
+        XCTAssertFalse(destination.shouldLevelBeLogged(.Verbose,
             path: "hello.swift",
             function: "foo",
-            message: "bar"))
+            message: "rab"))
 
-        // not in filter and below global minLevel
+        // test that excludes keeps the log from showing
         XCTAssertFalse(destination.shouldLevelBeLogged(.Debug,
             path: "hello.swift",
             function: "foo",

--- a/SwiftyBeaverTests/BaseDestinationTests.swift
+++ b/SwiftyBeaverTests/BaseDestinationTests.swift
@@ -147,7 +147,7 @@ class BaseDestinationTests: XCTestCase {
 
     func test_shouldLevelBeLogged_hasMinLevelAndMatchingLevelAndEqualPath_True() {
         let destination = BaseDestination()
-        destination.minLevel = SwiftyBeaver.Level.Info
+        destination.minLevel = .Debug
         let filter = Filters.Path.equals("/world/beaver.swift", caseSensitive: true, required: true, minLevel: .Debug)
         destination.addFilter(filter)
         XCTAssertTrue(destination.shouldLevelBeLogged(.Debug,
@@ -290,7 +290,7 @@ class BaseDestinationTests: XCTestCase {
 
     func test_shouldLevelBeLogged_hasMatchingNonRequiredFilter_True() {
         let destination = BaseDestination()
-        destination.minLevel = .Info
+        destination.minLevel = .Debug
         destination.addFilter(Filters.Path.contains("/ViewController"))
         XCTAssertTrue(destination.shouldLevelBeLogged(.Debug,
             path: "/world/ViewController.swift",
@@ -330,7 +330,7 @@ class BaseDestinationTests: XCTestCase {
     func test_shouldLevelBeLogged_multipleNonRequiredFiltersAndGlobal_True() {
         // everything is logged on default
         let destination = BaseDestination()
-        destination.minLevel = .Info
+        destination.minLevel = .Debug
 
         destination.addFilter(Filters.Path.contains("/ViewController", minLevel: .Debug))
         destination.addFilter(Filters.Function.contains("Func", minLevel: .Debug))
@@ -343,9 +343,14 @@ class BaseDestinationTests: XCTestCase {
             path: "/world/ViewController.swift",
             function: "myFunc",
             message: "Hello World"))
+        
+        XCTAssertFalse(destination.shouldLevelBeLogged(.Verbose,
+            path: "/world/ViewController.swift",
+            function: "myFunc",
+            message: "Hello World"))
 
         // not in filter but matching global minLevel
-        XCTAssertTrue(destination.shouldLevelBeLogged(.Info,
+        XCTAssertFalse(destination.shouldLevelBeLogged(.Info,
             path: "hello.swift",
             function: "foo",
             message: "bar"))

--- a/sources/BaseDestination.swift
+++ b/sources/BaseDestination.swift
@@ -235,11 +235,11 @@ public class BaseDestination: Hashable, Equatable {
                 return false
             }
         } else {
-            if level.rawValue >= minLevel.rawValue {
+            if level.rawValue < minLevel.rawValue {
                 if debugPrint {
                     print("filters is not empty and level >= minLevel")
                 }
-                return true
+                return false
             }
         }
 


### PR DESCRIPTION
Before the logs with filters never where able to get to a filter check if the log level is greater than or equal to minLevel. Changed to make sure filters are ran for logs that meet the minLevel.