### PR TITLE
Proposal: Use `add(destinations:)` in favour of `addDestination`

### DIFF
--- a/sources/SwiftyBeaver.swift
+++ b/sources/SwiftyBeaver.swift
@@ -38,6 +38,10 @@ open class SwiftyBeaver {
         destinations.insert(destination)
         return true
     }
+    
+    public class func add(destinations: [BaseDestination]) {
+        destinations.forEach { addDestination($0) }
+    }
 
     /// returns boolean about success
     @discardableResult
@@ -47,6 +51,10 @@ open class SwiftyBeaver {
         }
         destinations.remove(destination)
         return true
+    }
+    
+    public class func remove(destinations: [BaseDestination]) {
+        destinations.forEach { removeDestination($0) }
     }
 
     /// if you need to start fresh


### PR DESCRIPTION
## This is a proposal

**Rationale**
Currently it feels like there's a certain overhead when doing calls to `addDestination` instead of only providing a list of destinations e.g. how `Fabric` gets initialized with it's kits e.g.

```
 Fabric.with([Crashlytics.self])
```

**Currently it's**

```
let console = ConsoleDestination()  // log to Xcode Console
let file = FileDestination()  // log to default swiftybeaver.log file
let cloud = SBPlatformDestination(
  appID: id,
  appSecret: secret,
  encryptionKey: key
) // to cloud
SwiftyBeaver.addDestination(console)
SwiftyBeaver.addDestination(file)
SwiftyBeaver.addDestination(cloud)
```

**Proposed Solution**
For `SwiftyBeaver` this might look like e.g.

```
SwiftyBeaver.add(destinations: [
  ConsoleDestination(), 
  FileDestination(),
  SBPlatformDestination(
    appID: id,
    appSecret: secret,
    encryptionKey: key
  )
])
```

What do you reckon? Do you think this might be a way to go?
If you'd like to go down this path we should add some tests and think of changing the underlying logics so the other methods can be deprecated at some point.