### PR TITLE
Explicitly set tvOS deployment target

### DIFF
--- a/SwiftyBeaver.xcodeproj/project.pbxproj
+++ b/SwiftyBeaver.xcodeproj/project.pbxproj
@@ -784,6 +784,7 @@
 				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALID_ARCHS = "$(ARCHS_STANDARD)";
 			};
 			name = Debug;
@@ -809,6 +810,7 @@
 				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALID_ARCHS = "$(ARCHS_STANDARD)";
 			};
 			name = Release;


### PR DESCRIPTION
Previously there was to deployment target set so Xcode
assumed the latest installed deployment target automatically
which lead to #171. This attempts to fix #171.