### PR TITLE
Add NullDestination for letting your logs die in the ether

### DIFF
--- a/Sources/NullDestination.swift
+++ b/Sources/NullDestination.swift
@@ -1,0 +1,15 @@
+//
+//  NullDestination.swift
+//  SwiftyBeaver
+//
+//  Created by Kehrig, Andrew on 4/14/17.
+
+import Foundation
+
+public class NullDestination : BaseDestination {
+    override public func send(_ level: SwiftyBeaver.Level, msg: String, thread: String,
+                              file: String, function: String, line: Int) -> String? {
+        let formattedString = super.send(level, msg: msg, thread: thread, file: file, function: function, line: line)
+        return formattedString
+    }
+}

--- a/SwiftyBeaver.xcodeproj/project.pbxproj
+++ b/SwiftyBeaver.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		4D1720E51E9C071000AB7833 /* GoogleCloudDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D1720E41E9C071000AB7833 /* GoogleCloudDestination.swift */; };
 		4D1720E81E9C083600AB7833 /* GoogleCloudDestinationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D1720E71E9C083600AB7833 /* GoogleCloudDestinationTests.swift */; };
+		92EAC6E51EA171DD0002A855 /* NullDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EAC6E41EA171DD0002A855 /* NullDestination.swift */; };
 		9E195B0A1C6B3B4600D924CB /* AES256CBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E195B091C6B3B4600D924CB /* AES256CBC.swift */; };
 		9E195B0B1C6B3B4600D924CB /* AES256CBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E195B091C6B3B4600D924CB /* AES256CBC.swift */; };
 		9E195B0C1C6B3B4600D924CB /* AES256CBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E195B091C6B3B4600D924CB /* AES256CBC.swift */; };
@@ -69,6 +70,7 @@
 /* Begin PBXFileReference section */
 		4D1720E41E9C071000AB7833 /* GoogleCloudDestination.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GoogleCloudDestination.swift; path = Sources/GoogleCloudDestination.swift; sourceTree = "<group>"; };
 		4D1720E71E9C083600AB7833 /* GoogleCloudDestinationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GoogleCloudDestinationTests.swift; path = Tests/SwiftyBeaverTests/GoogleCloudDestinationTests.swift; sourceTree = "<group>"; };
+		92EAC6E41EA171DD0002A855 /* NullDestination.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NullDestination.swift; path = Sources/NullDestination.swift; sourceTree = "<group>"; };
 		9E11A1DA1D92654E002112B6 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .swiftlint.yml; sourceTree = "<group>"; };
 		9E195B091C6B3B4600D924CB /* AES256CBC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AES256CBC.swift; path = sources/AES256CBC.swift; sourceTree = "<group>"; };
 		9E195B101C6B766D00D924CB /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -178,6 +180,7 @@
 				9EA06DB41D083C9D001DB20A /* SBPlatformDestination.swift */,
 				9E31D6281C185ECD004E0980 /* SwiftyBeaver.swift */,
 				4D1720E41E9C071000AB7833 /* GoogleCloudDestination.swift */,
+				92EAC6E41EA171DD0002A855 /* NullDestination.swift */,
 			);
 			name = Sources;
 			sourceTree = "<group>";
@@ -473,6 +476,7 @@
 				9E31D62F1C185EE3004E0980 /* ConsoleDestination.swift in Sources */,
 				9E31D6291C185ECD004E0980 /* SwiftyBeaver.swift in Sources */,
 				9E31D6301C185EE3004E0980 /* FileDestination.swift in Sources */,
+				92EAC6E51EA171DD0002A855 /* NullDestination.swift in Sources */,
 				9E195B0A1C6B3B4600D924CB /* AES256CBC.swift in Sources */,
 				4D1720E51E9C071000AB7833 /* GoogleCloudDestination.swift in Sources */,
 				9EA06DB51D083C9D001DB20A /* SBPlatformDestination.swift in Sources */,


### PR DESCRIPTION
In enterprises, it’s common for “secret” data to not be logged or sent anywhere. This is just an easy helper destination to use with a conditional in case you need to do just that.

For instance, with this you could wrap your `log.addDestination()` calls in an `#if DEBUG` param check, and then have your `#else` look something like:
```swift
#else
log.addDestination(NullDestination())
#endif
```


This is such a small/easy addition to do on your own, I understand if it doesn't need to be included as part of the base repository. It's easy enough to add destinations thanks to how modular you've made SwiftyBeaver so far.

Thanks for all the hard work!