### PR TITLE
Added support for more watchOS versions

### DIFF
--- a/SwiftyBeaver.xcodeproj/project.pbxproj
+++ b/SwiftyBeaver.xcodeproj/project.pbxproj
@@ -745,6 +745,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
 				VALID_ARCHS = "$(ARCHS_STANDARD)";
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
 			name = Debug;
 		};
@@ -770,6 +771,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VALID_ARCHS = "$(ARCHS_STANDARD)";
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Thanks for an awesome library!!

I started migrating my app to SwiftyBeaver and everything worked great, but my beta users started giving me sad faces because the target watchOS version was too high (it's only supporting the very latest watchOS version).

So I lowered the watchOS version to 3.0 and everything still works and unit tests pass. Would you consider widening the watchOS support like all the other platforms?