### PR TITLE
Fix validation of required filters

### DIFF
--- a/Sources/BaseDestination.swift
+++ b/Sources/BaseDestination.swift
@@ -359,22 +359,17 @@ open class BaseDestination: Hashable, Equatable {
                                                                    function: function, message: message)
         let (matchedNonRequired, allNonRequired) = passedNonRequiredFilters(level, path: path,
                                                                     function: function, message: message)
-        if allRequired > 0 {
-            if matchedRequired == allRequired {
-                return true
-            }
-        } else {
-            // no required filters are existing so at least 1 optional needs to match
-            if allNonRequired > 0 {
-                if matchedNonRequired > 0 {
-                    return true
-                }
-            } else if allExclude == 0 {
-                // no optional is existing, so all is good
-                return true
-            }
-        }
 
+        // If required filters exist, we should validate or invalidate the log if all of them pass or not
+        if allRequired > 0 {
+            return matchedRequired == allRequired
+        }
+        
+        // If a non-required filter matches, the log is validated
+        if allNonRequired > 0 && matchedNonRequired > 0 {
+            return true
+        }
+        
         if level.rawValue < minLevel.rawValue {
             if debugPrint {
                 print("filters is not empty and level < minLevel")

--- a/Tests/SwiftyBeaverTests/BaseDestinationTests.swift
+++ b/Tests/SwiftyBeaverTests/BaseDestinationTests.swift
@@ -322,6 +322,20 @@ class BaseDestinationTests: XCTestCase {
                                                        path: "/hello/foo.swift", function: "initialize"))
     }
 
+    func test_shouldLevelBeLogged_hasMinLevelAndOneRequiredMessageFilterAndDoesNotPass_False() {
+        let destination = BaseDestination()
+        destination.minLevel = .error
+        destination.addFilter(Filters.Message.contains("Required", caseSensitive: false, required: true, minLevel: .info))
+        XCTAssertFalse(destination.shouldLevelBeLogged(.info, path: "/hello/foo.swift", function: "initialize", message: "Test"))
+    }
+    
+    func test_shouldLevelBeLogged_hasMinLevelAndOneRequiredMessageFilterAndDoesPass_True() {
+        let destination = BaseDestination()
+        destination.minLevel = SwiftyBeaver.Level.error
+        destination.addFilter(Filters.Message.contains("Required", caseSensitive: false, required: true, minLevel: .info))
+        XCTAssertTrue(destination.shouldLevelBeLogged(.info, path: "/hello/foo.swift", function: "initialize", message: "Required Test"))
+    }
+    
     func test_shouldLevelBeLogged_hasLevelFilterAndTwoRequiredPathFiltersAndPasses_True() {
         let destination = BaseDestination()
         destination.minLevel = SwiftyBeaver.Level.info


### PR DESCRIPTION
As in #185, required filter still doesn't work properly.

```
        if allRequired > 0 {
            if matchedRequired == allRequired {
                return true
            }
        } else {
           // ....
        }

        if level.rawValue < minLevel.rawValue {
           // other code that can eventually return true
        }
```
https://github.com/SwiftyBeaver/SwiftyBeaver/blob/master/Sources/BaseDestination.swift#L362-L378

If I have a required filter that is not matched, the `matchedRequired == allRequired` will not be equal, and then the code flow would just skip to the check about the destination min level. Instead, it should be `return matchedRequired == allRequired` to see if the validation succeeds or not. If those values are not equal, means that at least one required validator didn't pass, so the log should be discarded.