### PR TITLE
Fixes issue with multiple destinations with message filters

### DIFF
--- a/Sources/SwiftyBeaver.swift
+++ b/Sources/SwiftyBeaver.swift
@@ -130,7 +130,7 @@ open class SwiftyBeaver {
                 continue
             }
 
-            resolvedMessage = resolvedMessage == nil && dest.hasMessageFilters() ? "\(message())" : nil
+            resolvedMessage = resolvedMessage == nil && dest.hasMessageFilters() ? "\(message())" : resolvedMessage
             if dest.shouldLevelBeLogged(level, path: file, function: function, message: resolvedMessage) {
                 // try to convert msg object to String and put it on queue
                 let msgStr = resolvedMessage == nil ? "\(message())" : resolvedMessage!


### PR DESCRIPTION
Here is another bug fix PR ;)

Basically if you have two or more destinations with a message filter attached, the message itself is analyzed just by the destinations with odd indexes (1st, 3rd...).

```
var resolvedMessage: String?
for dest in destinations {
   // ...
   resolvedMessage = resolvedMessage == nil && dest.hasMessageFilters() ? "\(message())" : nil
    if dest.shouldLevelBeLogged(level, path: file, function: function, message: resolvedMessage) {

```
[Here](https://github.com/SwiftyBeaver/SwiftyBeaver/blob/master/Sources/SwiftyBeaver.swift#L126-L134)

On the first destination, `resolvedMessage` will be nil, and `dest.hasMessageFilters()` will return true, so `resolvedMessage` will contain the disclosed message from the autoclosure.
Then the problem: on second destination, `resolvedMessage` will not be nil anymore, obviously. At that point the code will flow to the second part of the ternary operator ` _ ? _ : _`, that will reassign nil to `resolvedMessage`. So the following `shouldLevelBeLogged` call will not carry the message information (that is needed, since the destination has message filters).
 
The solution is simple: the fallback value of the ternary operator should just be `resolvedMessage` itself. 
I added some tests on both the `shouldLevelBeLogged` and `send` calls, so that we are sure that all the expected params are passed to both methods.