### PR TITLE
String counting works under Swift 3.1 & Swift 3.2+

### DIFF
--- a/Sources/AES256CBC.swift
+++ b/Sources/AES256CBC.swift
@@ -840,14 +840,3 @@ fileprivate extension Data {
     }
 }
 
-extension String {
-    /// cross-Swift-version-compatible characters count
-    var length: Int {
-        #if swift(>=3.2)
-            return self.count
-        #else
-            return self.characters.count
-        #endif
-    }
-}
-

--- a/Sources/AES256CBC.swift
+++ b/Sources/AES256CBC.swift
@@ -33,7 +33,7 @@ final class AES256CBC {
     /// automatically generates and puts a random IV at first 16 chars
     /// the password must be exactly 32 chars long for AES-256
     class func encryptString(_ str: String, password: String) -> String? {
-        if !str.isEmpty && password.count == 32 {
+        if !str.isEmpty && password.length == 32 {
             let iv = randomText(16)
             let key = password
 
@@ -49,7 +49,7 @@ final class AES256CBC {
     /// returns optional decrypted string via AES-256CBC
     /// IV need to be at first 16 chars, password must be 32 chars long
     class func decryptString(_ str: String, password: String) -> String? {
-        if str.count > 16 && password.count == 32 {
+        if str.length > 16 && password.length == 32 {
             // get AES initialization vector from first 16 chars
             #if swift(>=4.0)
             let iv = String(str[..<str.index(str.startIndex, offsetBy: 16)])
@@ -837,6 +837,17 @@ fileprivate extension Array {
 fileprivate extension Data {
     var bytes: Array<UInt8> {
         return Array(self)
+    }
+}
+
+extension String {
+    /// cross-Swift-version-compatible characters count
+    var length: Int {
+        #if swift(>=3.2)
+            return self.count
+        #else
+            return self.characters.count
+        #endif
     }
 }
 

--- a/Sources/BaseDestination.swift
+++ b/Sources/BaseDestination.swift
@@ -284,9 +284,9 @@ open class BaseDestination: Hashable, Equatable {
         }
 
         // remove the leading {"key":" from the json string and the final }
-        let offset = key.count + 5
+        let offset = key.length + 5
         let endIndex = str.index(str.startIndex,
-                                 offsetBy: str.count - 2)
+                                 offsetBy: str.length - 2)
         let range = str.index(str.startIndex, offsetBy: offset)..<endIndex
         #if swift(>=3.2)
         return String(str[range])

--- a/Sources/Extensions.swift
+++ b/Sources/Extensions.swift
@@ -18,14 +18,17 @@ extension String {
         #endif
     }
     
-    var first: Character? {
+    /// cross-Swift-compatible first character
+    var firstChar: Character? {
         #if swift(>=3.2)
             return self.first
         #else
             return self.characters.first
         #endif
     }
-    var last: Character? {
+    
+    /// cross-Swift-compatible last character
+    var lastChar: Character? {
         #if swift(>=3.2)
             return self.last
         #else
@@ -33,7 +36,7 @@ extension String {
         #endif
     }
     
-    /// cross-Swift compatible index
+    /// cross-Swift-compatible index
     func find(_ char: Character) ->  Index? {
         #if swift(>=3.2)
             return self.index(of: char)

--- a/Sources/Extensions.swift
+++ b/Sources/Extensions.swift
@@ -1,0 +1,45 @@
+//
+//  Extensions.swift
+//  SwiftyBeaver
+//
+//  Created by Sebastian Kreutzberger on 13.12.17.
+//  Copyright © 2017 Sebastian Kreutzberger. All rights reserved.
+//
+
+import Foundation
+
+extension String {
+    /// cross-Swift compatible characters count
+    var length: Int {
+        #if swift(>=3.2)
+            return self.count
+        #else
+            return self.characters.count
+        #endif
+    }
+    
+    var first: Character? {
+        #if swift(>=3.2)
+            return self.first
+        #else
+            return self.characters.first
+        #endif
+    }
+    var last: Character? {
+        #if swift(>=3.2)
+            return self.last
+        #else
+            return self.characters.last
+        #endif
+    }
+    
+    /// cross-Swift compatible index
+    func find(_ char: Character) ->  Index? {
+        #if swift(>=3.2)
+            return self.index(of: char)
+        #else
+            return self.characters.index(of: char)
+        #endif
+    }
+}
+

--- a/Sources/SBPlatformDestination.swift
+++ b/Sources/SBPlatformDestination.swift
@@ -415,7 +415,7 @@ public class SBPlatformDestination: BaseDestination {
             var dicts = [[String: Any]()] // array of dictionaries
             for lineJSON in linesArray {
                 lines += 1
-                if lineJSON.first == "{" && lineJSON.last == "}" {
+                if lineJSON.firstChar == "{" && lineJSON.lastChar == "}" {
                     // try to parse json string into dict
                     if let data = lineJSON.data(using: .utf8) {
                         do {

--- a/Sources/SBPlatformDestination.swift
+++ b/Sources/SBPlatformDestination.swift
@@ -244,7 +244,7 @@ public class SBPlatformDestination: BaseDestination {
                     toNSLog("Encrypting \(lines) log entries ...")
                     if let encryptedStr = encrypt(str) {
                         var msg = "Sending \(lines) encrypted log entries "
-                        msg += "(\(encryptedStr.count) chars) to server ..."
+                        msg += "(\(encryptedStr.length) chars) to server ..."
                         toNSLog(msg)
                         sendToServerAsync(encryptedStr) { ok, _ in
 

--- a/Sources/SwiftyBeaver.swift
+++ b/Sources/SwiftyBeaver.swift
@@ -178,7 +178,7 @@ open class SwiftyBeaver {
     /// removes the parameters from a function because it looks weird with a single param
     class func stripParams(function: String) -> String {
         var f = function
-        if let indexOfBrace = f.index(of: "(") {
+        if let indexOfBrace = f.find("(") {
             #if swift(>=4.0)
             f = String(f[..<indexOfBrace])
             #else

--- a/SwiftyBeaver.xcodeproj/project.pbxproj
+++ b/SwiftyBeaver.xcodeproj/project.pbxproj
@@ -20,6 +20,10 @@
 		9E2AEAD61D9BB46300F21B1F /* SBPlatformDestinationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E2AEACD1D9BB46300F21B1F /* SBPlatformDestinationTests.swift */; };
 		9E2AEAD81D9BB46300F21B1F /* SecretsExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E2AEACF1D9BB46300F21B1F /* SecretsExample.swift */; };
 		9E2AEAD91D9BB46300F21B1F /* SwiftyBeaverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E2AEAD01D9BB46300F21B1F /* SwiftyBeaverTests.swift */; };
+		9E8F38B61FE12E9800BE9A80 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8F38B51FE12E9800BE9A80 /* Extensions.swift */; };
+		9E8F38B81FE12E9800BE9A80 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8F38B51FE12E9800BE9A80 /* Extensions.swift */; };
+		9E8F38B91FE12E9800BE9A80 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8F38B51FE12E9800BE9A80 /* Extensions.swift */; };
+		9E8F38BA1FE12E9800BE9A80 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8F38B51FE12E9800BE9A80 /* Extensions.swift */; };
 		9EDCE3EF1C09D211002FA4A7 /* SwiftyBeaver.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EDCE3E41C09D211002FA4A7 /* SwiftyBeaver.framework */; };
 		CB0FC3071EB8ABA00094E03A /* AES256CBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5233FE1EB0EB4600739CFB /* AES256CBC.swift */; };
 		CB0FC3081EB8ABA00094E03A /* BaseDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5233FF1EB0EB4600739CFB /* BaseDestination.swift */; };
@@ -85,6 +89,7 @@
 		9E6CAA471C148EC1009D9093 /* SwiftyBeaver.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SwiftyBeaver.podspec; sourceTree = "<group>"; };
 		9E6CAA491C149579009D9093 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		9E74FEA81CD74AFA0024DD76 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
+		9E8F38B51FE12E9800BE9A80 /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Extensions.swift; path = sources/Extensions.swift; sourceTree = SOURCE_ROOT; };
 		9EA8054D1D9BB54100348BC6 /* Dockerfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Dockerfile; sourceTree = "<group>"; };
 		9EDCE3E41C09D211002FA4A7 /* SwiftyBeaver.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyBeaver.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9EDCE3EE1C09D211002FA4A7 /* SwiftyBeaverTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftyBeaverTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -179,6 +184,7 @@
 				CB5234041EB0EB4600739CFB /* SBPlatformDestination.swift */,
 				CB5234051EB0EB4600739CFB /* SwiftyBeaver.swift */,
 				4D331ADE1F1E8E1100B1C25E /* Base64.swift */,
+				9E8F38B51FE12E9800BE9A80 /* Extensions.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -436,6 +442,7 @@
 				CB52340C1EB0EB4600739CFB /* SBPlatformDestination.swift in Sources */,
 				CB52340D1EB0EB4600739CFB /* SwiftyBeaver.swift in Sources */,
 				4D331AE01F1E8EA700B1C25E /* Base64.swift in Sources */,
+				9E8F38B61FE12E9800BE9A80 /* Extensions.swift in Sources */,
 				CB5234081EB0EB4600739CFB /* ConsoleDestination.swift in Sources */,
 				CB52340A1EB0EB4600739CFB /* Filter.swift in Sources */,
 				CB5234091EB0EB4600739CFB /* FileDestination.swift in Sources */,
@@ -468,6 +475,7 @@
 				CB0FC30C1EB8ABA00094E03A /* GoogleCloudDestination.swift in Sources */,
 				CB0FC30B1EB8ABA00094E03A /* Filter.swift in Sources */,
 				4D331AE21F1E8EAC00B1C25E /* Base64.swift in Sources */,
+				9E8F38B81FE12E9800BE9A80 /* Extensions.swift in Sources */,
 				CB0FC3071EB8ABA00094E03A /* AES256CBC.swift in Sources */,
 				CB0FC30A1EB8ABA00094E03A /* FileDestination.swift in Sources */,
 				CB0FC30D1EB8ABA00094E03A /* SBPlatformDestination.swift in Sources */,
@@ -484,6 +492,7 @@
 				CB0FC3141EB8ABA10094E03A /* GoogleCloudDestination.swift in Sources */,
 				CB0FC3131EB8ABA10094E03A /* Filter.swift in Sources */,
 				4D331AE11F1E8EAB00B1C25E /* Base64.swift in Sources */,
+				9E8F38B91FE12E9800BE9A80 /* Extensions.swift in Sources */,
 				CB0FC30F1EB8ABA10094E03A /* AES256CBC.swift in Sources */,
 				CB0FC3121EB8ABA10094E03A /* FileDestination.swift in Sources */,
 				CB0FC3151EB8ABA10094E03A /* SBPlatformDestination.swift in Sources */,
@@ -500,6 +509,7 @@
 				CB0FC31C1EB8ABA10094E03A /* GoogleCloudDestination.swift in Sources */,
 				CB0FC31B1EB8ABA10094E03A /* Filter.swift in Sources */,
 				4D331ADF1F1E8E1100B1C25E /* Base64.swift in Sources */,
+				9E8F38BA1FE12E9800BE9A80 /* Extensions.swift in Sources */,
 				CB0FC3171EB8ABA10094E03A /* AES256CBC.swift in Sources */,
 				CB0FC31A1EB8ABA10094E03A /* FileDestination.swift in Sources */,
 				CB0FC31D1EB8ABA10094E03A /* SBPlatformDestination.swift in Sources */,

--- a/Tests/SwiftyBeaverTests/AES256CBCTests.swift
+++ b/Tests/SwiftyBeaverTests/AES256CBCTests.swift
@@ -72,7 +72,7 @@ class AES256CBCTests: XCTestCase {
         //NSLog("encrypted: \(encrypted)")
 
         if let encrypted = encrypted {
-            XCTAssertGreaterThan(encrypted.count, 16)
+            XCTAssertGreaterThan(encrypted.length, 16)
             // decrypt
             let decrypted = AES256CBC.decryptString(encrypted, password: password)
             XCTAssertNotNil(decrypted)
@@ -119,8 +119,8 @@ class AES256CBCTests: XCTestCase {
     func testGeneratePassword() {
         let pw = AES256CBC.generatePassword()
         let pw2 = AES256CBC.generatePassword()
-        XCTAssertEqual(pw.count, 32)
-        XCTAssertEqual(pw2.count, 32)
+        XCTAssertEqual(pw.length, 32)
+        XCTAssertEqual(pw2.length, 32)
         XCTAssertNotEqual(pw, pw2)
         XCTAssertNil(pw.range(of: " "))
         XCTAssertNil(pw2.range(of: " "))

--- a/Tests/SwiftyBeaverTests/AES256CBCTests.swift
+++ b/Tests/SwiftyBeaverTests/AES256CBCTests.swift
@@ -30,7 +30,7 @@ class AES256CBCTests: XCTestCase {
         //printn("encrypted secret (IV is at first 16 chars): \(encrypted)")
 
         if let encrypted = encrypted {
-            XCTAssertGreaterThan(encrypted.count, 16)
+            XCTAssertGreaterThan(encrypted.length, 16)
             // decrypt
             let decrypted = AES256CBC.decryptString(encrypted, password: password)
             //print("decrypted str: \(decrypted)")
@@ -109,8 +109,8 @@ class AES256CBCTests: XCTestCase {
         let length = 6
         let text = AES256CBC.randomText(length)
         let text2 = AES256CBC.randomText(length)
-        XCTAssertEqual(text.count, length)
-        XCTAssertEqual(text2.count, length)
+        XCTAssertEqual(text.length, length)
+        XCTAssertEqual(text2.length, length)
         XCTAssertNotEqual(text, text2)
         XCTAssertNil(text.range(of: " "))
         XCTAssertNil(text2.range(of: " "))

--- a/Tests/SwiftyBeaverTests/GoogleCloudDestinationTests.swift
+++ b/Tests/SwiftyBeaverTests/GoogleCloudDestinationTests.swift
@@ -40,8 +40,8 @@ class GoogleCloudDestinationTests: XCTestCase {
         let str = gcpDestination.send(.verbose, msg: msg, thread: thread, file: file, function: function, line: line)
         XCTAssertNotNil(str)
         if let str = str {
-            XCTAssertEqual(str.first, "{")
-            XCTAssertEqual(str.last, "}")
+            XCTAssertEqual(str.firstChar, "{")
+            XCTAssertEqual(str.lastChar, "}")
             XCTAssertNotNil(str.range(of: "{\"service\":\"TEST\"}"))
             XCTAssertNotNil(str.range(of: "\"severity\":\"DEBUG\""))
             XCTAssertNotNil(str.range(of: "\"message\":\"test message\\nNewlineäößø\""))
@@ -63,8 +63,8 @@ class GoogleCloudDestinationTests: XCTestCase {
 
         XCTAssertNotNil(str)
         if let str = str {
-            XCTAssertEqual(str.first, "{")
-            XCTAssertEqual(str.last, "}")
+            XCTAssertEqual(str.firstChar, "{")
+            XCTAssertEqual(str.lastChar, "}")
             XCTAssertNotNil(str.range(of: "{\"service\":\"SwiftyBeaver\"}"))
             XCTAssertNotNil(str.range(of: "\"severity\":\"DEBUG\""))
             XCTAssertNotNil(str.range(of: "\"message\":\"test message\\nNewlineäößø\""))

--- a/Tests/SwiftyBeaverTests/SBPlatformDestinationTests.swift
+++ b/Tests/SwiftyBeaverTests/SBPlatformDestinationTests.swift
@@ -249,8 +249,8 @@ class SBPlatformDestinationTests: XCTestCase {
     func testDeviceDetails() {
         let device = platform.deviceDetails()
         XCTAssertEqual(device["os"], OS)
-        XCTAssertGreaterThan(device["os"]!.count, 0)
-        XCTAssertGreaterThan(device["osVersion"]!.count, 4)
+        XCTAssertGreaterThan(device["os"]!.length, 0)
+        XCTAssertGreaterThan(device["osVersion"]!.length, 4)
         XCTAssertEqual(device["hostName"], ProcessInfo.processInfo.hostName)
         XCTAssertEqual(device["deviceName"], DEVICE_NAME)
         XCTAssertEqual(device["deviceModel"], DEVICE_MODEL)

--- a/Tests/SwiftyBeaverTests/SBPlatformDestinationTests.swift
+++ b/Tests/SwiftyBeaverTests/SBPlatformDestinationTests.swift
@@ -266,14 +266,14 @@ class SBPlatformDestinationTests: XCTestCase {
         let dict = platform.analytics(platform.analyticsFileURL, update: false)
         print(dict)
         if let uuid = dict["uuid"] as? String {
-            XCTAssertEqual(uuid.count, 36)
+            XCTAssertEqual(uuid.length, 36)
             XCTAssertEqual(uuid, platform.analyticsUUID)
         }
         if let firstStart = dict["firstStart"] as? String {
-            XCTAssertEqual(firstStart.count, 23)
+            XCTAssertEqual(firstStart.length, 23)
         }
         if let lastStart = dict["lastStart"] as? String {
-            XCTAssertEqual(lastStart.count, 23)
+            XCTAssertEqual(lastStart.length, 23)
         }
         if let starts = dict["starts"] as? Int {
             XCTAssertGreaterThanOrEqual(starts, 1)

--- a/Tests/SwiftyBeaverTests/SwiftyBeaverTests.swift
+++ b/Tests/SwiftyBeaverTests/SwiftyBeaverTests.swift
@@ -294,7 +294,7 @@ class SwiftyBeaverTests: XCTestCase {
     }
 
     func testVersionAndBuild() {
-        XCTAssertGreaterThan(SwiftyBeaver.version.count, 4)
+        XCTAssertGreaterThan(SwiftyBeaver.version.length, 4)
         XCTAssertGreaterThan(SwiftyBeaver.build, 500)
     }
 


### PR DESCRIPTION
In version 1.4.3 we silenced deprecation warnings for Swift 3.2 and Swift 4 which unfortunately also removed support for Swift 3.1.

This PR here is bringing back support for Swift 3.1 but still silences the deprecation warnings under Swift 3.2+