### PR TITLE
If they exist, require at least one passing non-required filter

### DIFF
--- a/Sources/BaseDestination.swift
+++ b/Sources/BaseDestination.swift
@@ -378,9 +378,11 @@ open class BaseDestination: Hashable, Equatable {
         }
 
         // If a non-required filter matches, the log is validated
-        if allNonRequired > 0 && matchedNonRequired > 0 {
-            return true
-        }
+		if allNonRequired > 0 {  // Non-required filters exist
+
+			if matchedNonRequired > 0 { return true }  // At least one non-required filter matched
+			else { return false }  // No non-required filters matched
+		}
 
         if level.rawValue < minLevel.rawValue {
             if debugPrint {


### PR DESCRIPTION
Changes non-required filter behavior so that, when non-required filters exist, at least one non-required filter must match. Previously in this case it would exit the conditional block and be able to pass (return true) if the log level check passed.

This adds more flexibility to the log filtering; specifically it allows the scenario where you want to send logs to a destination ONLY if it matches *either* Case A or Case B.

Previously this setup,
```
someDestination.addFilter(Filters.Function.equals("methodA", required: false))
someDestination.addFilter(Filters.Function.equals("methodB", required: false))
```
resulted in all log messages being sent to someDestination, which isn't any different than not specifying filters. With this PR `someDestination` only received messages from `methodA` and `methodB`.

Shouldn't interfere with case where "required" Filters are present because those checks occur earlier in the code.