### PR TITLE
Added support to change SBPlatformDestination files's base directory

### DIFF
--- a/SwiftyBeaver.podspec
+++ b/SwiftyBeaver.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SwiftyBeaver"
-  s.version      = "1.5.2"
+  s.version      = "1.5.3"
   s.summary      = "Convenient logging during development & release in Swift 2, 3 & 4"
 
   # This description is used to generate tags and improve search results.


### PR DESCRIPTION
***Tested on iOS only ***
Since Apple started to expose the files in the document directory through the Files App, there was a need to hide debug files from the user.
The solution is to allow the developer to change the default directory for:
- entriesFileURL
- sendingFileURL
- analyticsFileURL