### PR TITLE
Padded format

### DIFF
--- a/Sources/BaseDestination.swift
+++ b/Sources/BaseDestination.swift
@@ -109,6 +109,44 @@ open class BaseDestination: Hashable, Equatable {
     // MARK: Format
     ////////////////////////////////
 
+    /// returns (padding length value, offset in string after padding info)
+    private func parsePadding(_ text: String) -> (Int, Int)
+    {
+        // look for digits followed by a alpha character
+        var s: String!
+        var sign: Int = 1
+        if text.firstChar == "-" {
+            sign = -1
+            s = String(text.suffix(from: text.index(text.startIndex, offsetBy: 1)))
+        } else {
+            s = text
+        }
+        let numStr = s.prefix { $0 >= "0" && $0 <= "9" }
+        if let num = Int(String(numStr)) {
+            return (sign * num, (sign == -1 ? 1 : 0) + numStr.count)
+        } else {
+            return (0, 0)
+        }
+    }
+    
+    private func paddedString(_ text: String, _ toLength: Int, truncating: Bool = false) -> String {
+        if toLength > 0 {
+            // Pad to the left of the string
+            if text.count > toLength {
+                // Hm... better to use suffix or prefix?
+                return truncating ? String(text.suffix(toLength)) : text
+            } else {
+                return "".padding(toLength: toLength - text.count, withPad: " ", startingAt: 0) + text
+            }
+        } else if toLength < 0 {
+            // Pad to the right of the string
+            let maxLength = truncating ? -toLength : max(-toLength, text.count)
+            return text.padding(toLength: maxLength, withPad: " ", startingAt: 0)
+        } else {
+            return text
+        }
+    }
+    
     /// returns the log message based on the format pattern
     func formatMessage(_ format: String, level: SwiftyBeaver.Level, msg: String, thread: String,
         file: String, function: String, line: Int, context: Any? = nil) -> String {
@@ -119,70 +157,69 @@ open class BaseDestination: Hashable, Equatable {
         let phrases: [String] = ("$I" + format).components(separatedBy: "$")
 
         for phrase in phrases where !phrase.isEmpty {
-                let formatChar = phrase[phrase.startIndex]
-                let rangeAfterFormatChar = phrase.index(phrase.startIndex, offsetBy: 1)..<phrase.endIndex
-                let remainingPhrase = phrase[rangeAfterFormatChar]
+            let (padding, offset) = parsePadding(phrase)
+            let formatCharIndex = phrase.index(phrase.startIndex, offsetBy: offset)
+            let formatChar = phrase[formatCharIndex]
+            let rangeAfterFormatChar = phrase.index(formatCharIndex, offsetBy: 1)..<phrase.endIndex
+            let remainingPhrase = phrase[rangeAfterFormatChar]
             
-                switch formatChar {
-                case "I":  // ignore
-                    text += remainingPhrase
-                case "L":
-                    text += levelWord(level) + remainingPhrase
-                case "M":
-                    text += msg + remainingPhrase
-                case "T":
-                    text += thread + remainingPhrase
-                case "N":
-                    // name of file without suffix
-                    text += fileNameWithoutSuffix(file) + remainingPhrase
-                case "n":
-                    // name of file with suffix
-                    text += fileNameOfFile(file) + remainingPhrase
-                case "F":
-                    text += function + remainingPhrase
-                case "l":
-                    text += String(line) + remainingPhrase
-                case "D":
-                    // start of datetime format
-                    #if swift(>=3.2)
-                    text += formatDate(String(remainingPhrase))
-                    #else
-                    text += formatDate(remainingPhrase)
-                    #endif
-                case "d":
-                    text += remainingPhrase
-                case "U":
-                    text += uptime() + remainingPhrase
-                case "Z":
-                    // start of datetime format in UTC timezone
-                    #if swift(>=3.2)
-                    text += formatDate(String(remainingPhrase), timeZone: "UTC")
-                    #else
-                    text += formatDate(remainingPhrase, timeZone: "UTC")
-                    #endif
-                case "z":
-                    text += remainingPhrase
-                case "C":
-                    // color code ("" on default)
-                    text += escape + colorForLevel(level) + remainingPhrase
-                case "c":
-                    text += reset + remainingPhrase
-                case "X":
-                    // add the context
-                    if let cx = context {
-                        text += String(describing: cx).trimmingCharacters(in: .whitespacesAndNewlines) + remainingPhrase
-                    } else {
-                        text += remainingPhrase
-                    }
-                    /*
-                    if let contextString = context as? String {
-                        text += contextString + remainingPhrase
-                    }*/
-                default:
-                    text += phrase
+            switch formatChar {
+            case "I":  // ignore
+                text += remainingPhrase
+            case "L":
+                text += paddedString(levelWord(level), padding) + remainingPhrase
+            case "M":
+                text += paddedString(msg, padding) + remainingPhrase
+            case "T":
+                text += paddedString(thread, padding) + remainingPhrase
+            case "N":
+                // name of file without suffix
+                text += paddedString(fileNameWithoutSuffix(file), padding) + remainingPhrase
+            case "n":
+                // name of file with suffix
+                text += paddedString(fileNameOfFile(file), padding) + remainingPhrase
+            case "F":
+                text += paddedString(function, padding) + remainingPhrase
+            case "l":
+                text += paddedString(String(line), padding) + remainingPhrase
+            case "D":
+                // start of datetime format
+                #if swift(>=3.2)
+                text += paddedString(formatDate(String(remainingPhrase)), padding)
+                #else
+                text += paddedString(formatDate(remainingPhrase), padding)
+                #endif
+            case "d":
+                text += remainingPhrase
+            case "U":
+                text += paddedString(uptime(), padding) + remainingPhrase
+            case "Z":
+                // start of datetime format in UTC timezone
+                #if swift(>=3.2)
+                text += paddedString(formatDate(String(remainingPhrase), timeZone: "UTC"), padding)
+                #else
+                text += paddedString(formatDate(remainingPhrase, timeZone: "UTC"), padding)
+                #endif
+            case "z":
+                text += remainingPhrase
+            case "C":
+                // color code ("" on default)
+                text += escape + colorForLevel(level) + remainingPhrase
+            case "c":
+                text += reset + remainingPhrase
+            case "X":
+                // add the context
+                if let cx = context {
+                    text += paddedString(String(describing: cx).trimmingCharacters(in: .whitespacesAndNewlines), padding) + remainingPhrase
+                } else {
+                    text += paddedString("", padding) + remainingPhrase
                 }
+            default:
+                text += phrase
+            }
         }
-        return text.trimmingCharacters(in: .whitespacesAndNewlines)
+        // right trim only
+        return text.replacingOccurrences(of: "\\s+$", with: "", options: .regularExpression)
     }
 
     /// returns the log payload as optional JSON string

--- a/Sources/BaseDestination.swift
+++ b/Sources/BaseDestination.swift
@@ -114,14 +114,18 @@ open class BaseDestination: Hashable, Equatable {
         file: String, function: String, line: Int, context: Any? = nil) -> String {
 
         var text = ""
-        let phrases: [String] = format.components(separatedBy: "$")
+        // Prepend a $I for 'ignore' or else the first character is interpreted as a format character
+        // even if the format string did not start with a $.
+        let phrases: [String] = ("$I" + format).components(separatedBy: "$")
 
         for phrase in phrases where !phrase.isEmpty {
-                let firstChar = phrase[phrase.startIndex]
-                let rangeAfterFirstChar = phrase.index(phrase.startIndex, offsetBy: 1)..<phrase.endIndex
-                let remainingPhrase = phrase[rangeAfterFirstChar]
-
-                switch firstChar {
+                let formatChar = phrase[phrase.startIndex]
+                let rangeAfterFormatChar = phrase.index(phrase.startIndex, offsetBy: 1)..<phrase.endIndex
+                let remainingPhrase = phrase[rangeAfterFormatChar]
+            
+                switch formatChar {
+                case "I":  // ignore
+                    text += remainingPhrase
                 case "L":
                     text += levelWord(level) + remainingPhrase
                 case "M":

--- a/Sources/BaseDestination.swift
+++ b/Sources/BaseDestination.swift
@@ -167,6 +167,8 @@ open class BaseDestination: Hashable, Equatable {
                     // add the context
                     if let cx = context {
                         text += String(describing: cx).trimmingCharacters(in: .whitespacesAndNewlines) + remainingPhrase
+                    } else {
+                        text += remainingPhrase
                     }
                     /*
                     if let contextString = context as? String {

--- a/Tests/SwiftyBeaverTests/BaseDestinationTests.swift
+++ b/Tests/SwiftyBeaverTests/BaseDestinationTests.swift
@@ -46,6 +46,16 @@ class BaseDestinationTests: XCTestCase {
                                 file: "/path/to/ViewController.swift", function: "testFunction()", line: 50)
         XCTAssertEqual(str, "Hello")
 
+        // format without variables (make sure the L is not interpreted as format character)
+        format = "Linda"
+        str = obj.formatMessage(format, level: .verbose, msg: "Hello", thread: "main",
+                                file: "/path/to/ViewController.swift", function: "testFunction()", line: 50)
+        XCTAssertEqual(str, "Linda")
+        format = "$Linda $M"
+        str = obj.formatMessage(format, level: .verbose, msg: "Hello", thread: "main",
+                                file: "/path/to/ViewController.swift", function: "testFunction()", line: 50)
+        XCTAssertEqual(str, "VERBOSEinda Hello")
+
         // weird format
         format = "$"
         str = obj.formatMessage(format, level: .verbose, msg: "Hello", thread: "main",

--- a/Tests/SwiftyBeaverTests/BaseDestinationTests.swift
+++ b/Tests/SwiftyBeaverTests/BaseDestinationTests.swift
@@ -34,8 +34,9 @@ class BaseDestinationTests: XCTestCase {
         let obj = BaseDestination()
         var str = ""
         var format = ""
-
+        
         // empty format
+        format = ""
         str = obj.formatMessage(format, level: .verbose, msg: "Hello", thread: "main",
             file: "/path/to/ViewController.swift", function: "testFunction()", line: 50)
         XCTAssertEqual(str, "")
@@ -123,6 +124,30 @@ class BaseDestinationTests: XCTestCase {
         // no context
         str = obj5.formatMessage(format, level: .verbose, msg: "Hello", thread: "main", file: "/path/to/ViewController.swift", function: "testFunction()", line: 50)
         XCTAssertEqual(str, "VERBOSE: [] Hello")
+        
+        
+        // misc. paddings
+        let obj6 = BaseDestination()
+        format = "[$-8L]"
+        str = obj6.formatMessage(format, level: .debug, msg: "Hello", thread: "main", file: "/path/to/ViewController.swift", function: "testFunction()", line: 50)
+        XCTAssertEqual(str, "[DEBUG   ]")
+        format = "$-8L"
+        str = obj6.formatMessage(format, level: .debug, msg: "Hello", thread: "main", file: "/path/to/ViewController.swift", function: "testFunction()", line: 50)
+        XCTAssertEqual(str, "DEBUG")
+        format = "$8L"
+        str = obj6.formatMessage(format, level: .debug, msg: "Hello", thread: "main", file: "/path/to/ViewController.swift", function: "testFunction()", line: 50)
+        XCTAssertEqual(str, "   DEBUG")
+        format = "$-8L:_$10X___$M"
+        str = obj6.formatMessage(format, level: .debug, msg: "Hello", thread: "main", file: "/path/to/ViewController.swift", function: "testFunction()", line: 50, context: "Context!")
+
+        obj6.levelColor.verbose = "?"
+        obj6.escape = ">"
+        obj6.reset = "<"
+        XCTAssertEqual(str, "DEBUG   :_  Context!___Hello")
+        format = "[$Dyyyy-MM-dd HH:mm:ss$d] |$T| $N.$F:$l $C$L$c: $M"
+        str = obj6.formatMessage(format, level: .verbose, msg: "Hello", thread: "main",
+                                 file: "/path/to/ViewController.swift", function: "testFunction()", line: 50)
+        XCTAssertEqual(str, "[\(dateStr)] |main| ViewController.testFunction():50 >?VERBOSE<: Hello")
     }
 
     func testMessageToJSON() {

--- a/Tests/SwiftyBeaverTests/BaseDestinationTests.swift
+++ b/Tests/SwiftyBeaverTests/BaseDestinationTests.swift
@@ -104,6 +104,15 @@ class BaseDestinationTests: XCTestCase {
         str = obj4.formatMessage(format, level: .verbose, msg: "Hello", thread: "main",
                                 file: "/path/to/ViewController.swift", function: "testFunction()", line: 50, context: nil)
         XCTAssertEqual(str, "VERBOSE: Hello")
+        
+        // context in the middle
+        let obj5 = BaseDestination()
+        format = "$L: [$X] $M"
+        str = obj5.formatMessage(format, level: .verbose, msg: "Hello", thread: "main", file: "/path/to/ViewController.swift", function: "testFunction()", line: 50, context: "Context!")
+        XCTAssertEqual(str, "VERBOSE: [Context!] Hello")
+        // no context
+        str = obj5.formatMessage(format, level: .verbose, msg: "Hello", thread: "main", file: "/path/to/ViewController.swift", function: "testFunction()", line: 50)
+        XCTAssertEqual(str, "VERBOSE: [] Hello")
     }
 
     func testMessageToJSON() {


### PR DESCRIPTION
Fixes issues/requests #294 and #295.

Bugs fixed:
* Context format specification with $X ate the remainingText if context was nil.
* First character in the format was potentially always treated as a format character, even without a $ prefix, so `"Level: $L"` would yield `"DEBUGevel: DEBUG"`.
New feature:
* Format supports padding for prettier output in console (with monospaced font)

Including unit tests for new functionality.

Documentation about the new format feature is not included (since those files are not part of this repo).

The new feature is to pad formatted output so that it has better readability in the console output with clean columns. Format is an extention of the existing

`$<formatChar>`

to 

`$<paddedLength><formatChar>`

Negative values give right padding, positive left padding. E.g. a format of

$-8L $-10X line=$3l $M

will give output such as

```
DEBUG    context1   line=  1 Debugging context1 and line1
VERBOSE  context12  line= 12 Verbose output from context12 and line12
```

Strings that exceed the specified length are currently not truncated, but the function that creates the padded string can take a "truncating: true" for future expansion in case we want to add this option, e.g. "console.truncatePaddedFormat = true".
