### PR TITLE
Provide execute() methods to run in destination queue

### DIFF
--- a/Sources/BaseDestination.swift
+++ b/Sources/BaseDestination.swift
@@ -105,6 +105,24 @@ open class BaseDestination: Hashable, Equatable {
         }
     }
 
+    public func execute(synchronously: Bool, block: @escaping () -> Void) {
+        guard let queue = queue else {
+            fatalError("Queue not set")
+        }
+        if synchronously {
+            queue.sync(execute: block)
+        } else {
+            queue.async(execute: block)
+        }
+    }
+    
+    public func executeSynchronously<T>(block: @escaping () throws -> T) rethrows -> T {
+        guard let queue = queue else {
+            fatalError("Queue not set")
+        }
+        return try queue.sync(execute: block)
+    }
+
     ////////////////////////////////
     // MARK: Format
     ////////////////////////////////


### PR DESCRIPTION
The `SwiftyBeaver` singleton uses the internal `BaseDestination.queue` to deliver messages with the overridden `send()`. If the destination needs to synchronize access to the current storage for other non-logging means (e.g. uploading a snapshot somewhere), there's no way to sync with the internal queue, because it's inaccessible to subclasses. If `send()` writes to a shared resource, mutex must be done on an additional queue.

Of course a refactoring is not viable, and exposing the queue may be too much. Providing a couple `execute()` methods to only expose what's necessary, both in sync and async fashion.

OT: could `queue` be made non-optional? I see it's optional to use target = self, but maybe it's some dragged legacy.