### PR TITLE
Use swift type inference to allow SwiftShield to obfuscate code

### DIFF
--- a/Sources/BaseDestination.swift
+++ b/Sources/BaseDestination.swift
@@ -264,16 +264,16 @@ open class BaseDestination: Hashable, Equatable {
         var str = ""
 
         switch level {
-        case SwiftyBeaver.Level.debug:
+        case .debug:
             str = levelString.debug
 
-        case SwiftyBeaver.Level.info:
+        case .info:
             str = levelString.info
 
-        case SwiftyBeaver.Level.warning:
+        case .warning:
             str = levelString.warning
 
-        case SwiftyBeaver.Level.error:
+        case .error:
             str = levelString.error
 
         default:
@@ -288,16 +288,16 @@ open class BaseDestination: Hashable, Equatable {
         var color = ""
 
         switch level {
-        case SwiftyBeaver.Level.debug:
+        case .debug:
             color = levelColor.debug
 
-        case SwiftyBeaver.Level.info:
+        case .info:
             color = levelColor.info
 
-        case SwiftyBeaver.Level.warning:
+        case .warning:
             color = levelColor.warning
 
-        case SwiftyBeaver.Level.error:
+        case .error:
             color = levelColor.error
 
         default:

--- a/Sources/SBPlatformDestination.swift
+++ b/Sources/SBPlatformDestination.swift
@@ -351,13 +351,13 @@ public class SBPlatformDestination: BaseDestination {
     func sendingPointsForLevel(_ level: SwiftyBeaver.Level) -> Int {
 
         switch level {
-        case SwiftyBeaver.Level.debug:
+        case .debug:
             return sendingPoints.debug
-        case SwiftyBeaver.Level.info:
+        case .info:
             return sendingPoints.info
-        case SwiftyBeaver.Level.warning:
+        case .warning:
             return sendingPoints.warning
-        case SwiftyBeaver.Level.error:
+        case .error:
             return sendingPoints.error
         default:
             return sendingPoints.verbose


### PR DESCRIPTION
Looks like SourceKit doesn't support renaming nested classes used inside switch block, so I'd suggest using swift type inference for it.