### PR TITLE
Fixed logging issue in BaseDestination with non-required filters

### DIFF
--- a/Sources/Filter.swift
+++ b/Sources/Filter.swift
@@ -16,8 +16,8 @@ import Foundation
 ///
 /// A filter must contain a target, which identifies what it filters against
 /// A filter can be required meaning that all required filters against a specific
-/// target must pass in order for the message to be logged. At least one non-required
-/// filter must pass in order for the message to be logged
+/// target must pass in order for the message to be logged.
+
 public protocol FilterType : class {
     func apply(_ value: Any) -> Bool
     func getTarget() -> Filter.TargetType

--- a/Sources/FilterValidator.swift
+++ b/Sources/FilterValidator.swift
@@ -1,0 +1,129 @@
+//
+//  FilterValidator.swift
+//  SwiftyBeaver (iOS)
+//
+//  Created by Felix Lisczyk on 07.07.19.
+//  Copyright © 2019 Sebastian Kreutzberger. All rights reserved.
+//
+
+import Foundation
+
+/// FilterValidator is a utility class used by BaseDestination.
+/// It encapsulates the filtering logic for excluded, required
+/// and non-required filters.
+///
+/// FilterValidator evaluates a set of filters for a single log
+/// entry. It determines if these filters apply to the log entry
+/// based on their condition (path, function, message) and their
+/// minimum log level.
+
+struct FilterValidator {
+
+    // These are the different filter types that the user can set
+    enum ValidationType: CaseIterable {
+        case excluded
+        case required
+        case nonRequired
+
+        func apply(to filters: [FilterType]) -> [FilterType] {
+            switch self {
+            case .excluded:
+                return filters.filter { $0.isExcluded() }
+            case .required:
+                return filters.filter { $0.isRequired() && !$0.isExcluded() }
+            case .nonRequired:
+                return filters.filter { !$0.isRequired() && !$0.isExcluded() }
+            }
+        }
+    }
+
+    // Wrapper object for input parameters
+    struct Input {
+        let filters: [FilterType]
+        let level: SwiftyBeaver.Level
+        let path: String
+        let function: String
+        let message: String?
+    }
+
+    // Result wrapper object
+    enum Result {
+        case allFiltersMatch                            // All filters fully match the log entry (condition + minimum log level)
+        case someFiltersMatch(PartialMatchData)         // Only some filters fully match the log entry (condition + minimum log level)
+        case noFiltersMatchingType                      // There are no filters set for a particular type (excluded, required, nonRequired)
+
+        struct PartialMatchData {
+            let fullMatchCount: Int                     // Number of filters that match both the condition and the minimum log level of the log entry
+            let conditionMatchCount: Int                // Number of filters that match ONLY the condition of the log entry (path, function, message)
+            let logLevelMatchCount: Int                 // Number of filters that match ONLY the minimum log level of the log entry
+        }
+    }
+
+    static func validate(input: Input, for types: [ValidationType] = ValidationType.allCases) -> [ValidationType: Result] {
+        var results = [ValidationType: Result]()
+        for type in types {
+            let filtersToValidate = type.apply(to: input.filters)
+
+            if filtersToValidate.isEmpty {
+                // There are no filters set for this particular type
+                results[type] = .noFiltersMatchingType
+            } else {
+                var fullMatchCount: Int = 0
+                var conditionMatchCount: Int = 0
+                var logLevelMatchCount: Int = 0
+
+                for filter in filtersToValidate {
+                    let filterMatchesCondition = self.filterMatchesCondition(filter, level: input.level, path: input.path, function: input.function, message: input.message)
+                    let filterMatchesMinLogLevel = self.filterMatchesMinLogLevel(filter, level: input.level)
+
+                    switch (filterMatchesCondition, filterMatchesMinLogLevel) {
+                    // Filter matches both the condition and the minimum log level
+                    case (true, true): fullMatchCount += 1
+                    // Filter matches only the condition (path, function, message)
+                    case (true, false): conditionMatchCount += 1
+                    // Filter matches only the minimum log level
+                    case (false, true): logLevelMatchCount += 1
+                    // Filter does not match the condition nor the minimum log level
+                    case (false, false): break
+                    }
+                }
+
+                if filtersToValidate.count == fullMatchCount {
+                    // All filters fully match the log entry
+                    results[type] = .allFiltersMatch
+                } else {
+                    // Only some filters match the log entry
+                    results[type] = .someFiltersMatch(.init(fullMatchCount: fullMatchCount, conditionMatchCount: conditionMatchCount, logLevelMatchCount: logLevelMatchCount))
+                }
+            }
+        }
+
+        return results
+    }
+
+    private static func filterMatchesCondition(_ filter: FilterType, level: SwiftyBeaver.Level,
+                                                path: String, function: String, message: String?) -> Bool {
+            let passes: Bool
+
+            switch filter.getTarget() {
+            case .Path(_):
+                passes = filter.apply(path)
+
+            case .Function(_):
+                passes = filter.apply(function)
+
+            case .Message(_):
+                guard let message = message else {
+                    return false
+                }
+
+                passes = filter.apply(message)
+            }
+
+            return passes
+    }
+
+    private static func filterMatchesMinLogLevel(_ filter: FilterType, level: SwiftyBeaver.Level) -> Bool {
+        return filter.reachedMinLevel(level)
+    }
+}

--- a/SwiftyBeaver.xcodeproj/project.pbxproj
+++ b/SwiftyBeaver.xcodeproj/project.pbxproj
@@ -57,6 +57,10 @@
 		CB52340B1EB0EB4600739CFB /* GoogleCloudDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5234031EB0EB4600739CFB /* GoogleCloudDestination.swift */; };
 		CB52340C1EB0EB4600739CFB /* SBPlatformDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5234041EB0EB4600739CFB /* SBPlatformDestination.swift */; };
 		CB52340D1EB0EB4600739CFB /* SwiftyBeaver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5234051EB0EB4600739CFB /* SwiftyBeaver.swift */; };
+		DCC4D45E22D21920002B14E4 /* FilterValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC4D45D22D21920002B14E4 /* FilterValidator.swift */; };
+		DCC4D45F22D2192B002B14E4 /* FilterValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC4D45D22D21920002B14E4 /* FilterValidator.swift */; };
+		DCC4D46022D2192B002B14E4 /* FilterValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC4D45D22D21920002B14E4 /* FilterValidator.swift */; };
+		DCC4D46122D2192C002B14E4 /* FilterValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC4D45D22D21920002B14E4 /* FilterValidator.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -104,6 +108,7 @@
 		CB5234031EB0EB4600739CFB /* GoogleCloudDestination.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GoogleCloudDestination.swift; sourceTree = "<group>"; };
 		CB5234041EB0EB4600739CFB /* SBPlatformDestination.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SBPlatformDestination.swift; sourceTree = "<group>"; };
 		CB5234051EB0EB4600739CFB /* SwiftyBeaver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftyBeaver.swift; sourceTree = "<group>"; };
+		DCC4D45D22D21920002B14E4 /* FilterValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterValidator.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -176,15 +181,16 @@
 			isa = PBXGroup;
 			children = (
 				CB5233FE1EB0EB4600739CFB /* AES256CBC.swift */,
+				4D331ADE1F1E8E1100B1C25E /* Base64.swift */,
 				CB5233FF1EB0EB4600739CFB /* BaseDestination.swift */,
 				CB5234001EB0EB4600739CFB /* ConsoleDestination.swift */,
+				9E8F38B51FE12E9800BE9A80 /* Extensions.swift */,
 				CB5234011EB0EB4600739CFB /* FileDestination.swift */,
 				CB5234021EB0EB4600739CFB /* Filter.swift */,
+				DCC4D45D22D21920002B14E4 /* FilterValidator.swift */,
 				CB5234031EB0EB4600739CFB /* GoogleCloudDestination.swift */,
 				CB5234041EB0EB4600739CFB /* SBPlatformDestination.swift */,
 				CB5234051EB0EB4600739CFB /* SwiftyBeaver.swift */,
-				4D331ADE1F1E8E1100B1C25E /* Base64.swift */,
-				9E8F38B51FE12E9800BE9A80 /* Extensions.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -447,6 +453,7 @@
 				CB52340D1EB0EB4600739CFB /* SwiftyBeaver.swift in Sources */,
 				4D331AE01F1E8EA700B1C25E /* Base64.swift in Sources */,
 				9E8F38B61FE12E9800BE9A80 /* Extensions.swift in Sources */,
+				DCC4D45E22D21920002B14E4 /* FilterValidator.swift in Sources */,
 				CB5234081EB0EB4600739CFB /* ConsoleDestination.swift in Sources */,
 				CB52340A1EB0EB4600739CFB /* Filter.swift in Sources */,
 				CB5234091EB0EB4600739CFB /* FileDestination.swift in Sources */,
@@ -480,6 +487,7 @@
 				CB0FC30B1EB8ABA00094E03A /* Filter.swift in Sources */,
 				4D331AE21F1E8EAC00B1C25E /* Base64.swift in Sources */,
 				9E8F38B81FE12E9800BE9A80 /* Extensions.swift in Sources */,
+				DCC4D45F22D2192B002B14E4 /* FilterValidator.swift in Sources */,
 				CB0FC3071EB8ABA00094E03A /* AES256CBC.swift in Sources */,
 				CB0FC30A1EB8ABA00094E03A /* FileDestination.swift in Sources */,
 				CB0FC30D1EB8ABA00094E03A /* SBPlatformDestination.swift in Sources */,
@@ -497,6 +505,7 @@
 				CB0FC3131EB8ABA10094E03A /* Filter.swift in Sources */,
 				4D331AE11F1E8EAB00B1C25E /* Base64.swift in Sources */,
 				9E8F38B91FE12E9800BE9A80 /* Extensions.swift in Sources */,
+				DCC4D46022D2192B002B14E4 /* FilterValidator.swift in Sources */,
 				CB0FC30F1EB8ABA10094E03A /* AES256CBC.swift in Sources */,
 				CB0FC3121EB8ABA10094E03A /* FileDestination.swift in Sources */,
 				CB0FC3151EB8ABA10094E03A /* SBPlatformDestination.swift in Sources */,
@@ -514,6 +523,7 @@
 				CB0FC31B1EB8ABA10094E03A /* Filter.swift in Sources */,
 				4D331ADF1F1E8E1100B1C25E /* Base64.swift in Sources */,
 				9E8F38BA1FE12E9800BE9A80 /* Extensions.swift in Sources */,
+				DCC4D46122D2192C002B14E4 /* FilterValidator.swift in Sources */,
 				CB0FC3171EB8ABA10094E03A /* AES256CBC.swift in Sources */,
 				CB0FC31A1EB8ABA10094E03A /* FileDestination.swift in Sources */,
 				CB0FC31D1EB8ABA10094E03A /* SBPlatformDestination.swift in Sources */,

--- a/Tests/SwiftyBeaverTests/BaseDestinationTests.swift
+++ b/Tests/SwiftyBeaverTests/BaseDestinationTests.swift
@@ -517,6 +517,16 @@ class BaseDestinationTests: XCTestCase {
                                                        message: "Hello World"))
     }
 
+    func test_shouldLevelBeLogged_hasNoMatchingNonRequiredFilterAndMinLevel_True() {
+        let destination = BaseDestination()
+        destination.minLevel = .debug
+        destination.addFilter(Filters.Path.contains("/ViewController", minLevel: .info))
+        XCTAssertTrue(destination.shouldLevelBeLogged(.debug,
+                                                       path: "/world/beaver.swift",
+                                                       function: "myFunc",
+                                                       message: "Hello World"))
+    }
+
     func test_shouldLevelBeLogged_hasNoMatchingNonRequiredFilterAndMinLevel_False() {
         let destination = BaseDestination()
         destination.minLevel = .info
@@ -525,6 +535,17 @@ class BaseDestinationTests: XCTestCase {
                                                        path: "/world/ViewController.swift",
                                                        function: "myFunc",
                                                        message: "Hello World"))
+    }
+
+    func test_shouldLevelBeLogged_hasMultipleNonMatchingNonRequiredFilterAndMinLevel_True() {
+        let destination = BaseDestination()
+        destination.minLevel = .debug
+        destination.addFilter(Filters.Path.contains("/ViewController", minLevel: .info))
+        destination.addFilter(Filters.Path.contains("/test", minLevel: .debug))
+        XCTAssertTrue(destination.shouldLevelBeLogged(.debug,
+                                                      path: "/world/beaver.swift",
+                                                      function: "myFunc",
+                                                      message: "Hello World"))
     }
 
     func test_shouldLevelBeLogged_noFilters_True() {
@@ -586,12 +607,13 @@ class BaseDestinationTests: XCTestCase {
                                                        function: "otherFunc",
                                                        message: "Hello World"))
 
-        // not excluded, above minLevel but at least 1 non-required filtter has to match!
-        XCTAssertFalse(destination.shouldLevelBeLogged(.error,
+        // not excluded, above minLevel, no matching filter
+        XCTAssertTrue(destination.shouldLevelBeLogged(.error,
                                                       path: "/world/OtherViewController.swift",
                                                       function: "otherFunc",
                                                       message: "Hello World"))
-        
+
+        // not excluded, above minLevel, matching path filter
         XCTAssertTrue(destination.shouldLevelBeLogged(.error,
                                                        path: "/ViewController.swift",
                                                        function: "otherFunc",

--- a/Tests/SwiftyBeaverTests/BaseDestinationTests.swift
+++ b/Tests/SwiftyBeaverTests/BaseDestinationTests.swift
@@ -529,7 +529,7 @@ class BaseDestinationTests: XCTestCase {
 
     func test_shouldLevelBeLogged_hasNoMatchingNonRequiredFilterAndMinLevel_False() {
         let destination = BaseDestination()
-        destination.minLevel = .info
+        destination.minLevel = .verbose
         destination.addFilter(Filters.Path.contains("/ViewController", minLevel: .debug))
         XCTAssertFalse(destination.shouldLevelBeLogged(.verbose,
                                                        path: "/world/ViewController.swift",
@@ -546,6 +546,17 @@ class BaseDestinationTests: XCTestCase {
                                                       path: "/world/beaver.swift",
                                                       function: "myFunc",
                                                       message: "Hello World"))
+    }
+
+    func test_shouldLevelBeLogged_hasMultipleNonMatchingNonRequiredFilterAndMinLevel_False() {
+        let destination = BaseDestination()
+        destination.minLevel = .verbose
+        destination.addFilter(Filters.Path.contains("/ViewController", minLevel: .debug))
+        destination.addFilter(Filters.Path.contains("/test", minLevel: .verbose))
+        XCTAssertFalse(destination.shouldLevelBeLogged(.verbose,
+                                                       path: "/world/ViewController.swift",
+                                                       function: "myFunc",
+                                                       message: "Hello World"))
     }
 
     func test_shouldLevelBeLogged_noFilters_True() {


### PR DESCRIPTION
This issue was discussed in #339. When a destination has non-required filters set, it doesn't output any messages that are not matching at least one of these filters.

I've refactored the filtering logic from `BaseDestination` into a separate struct `FilterValidator`. Please feel free to rename, edit or move this file to another location. I've also added two new unit tests and documentation comments.