### PR TITLE
Create folder if not exist for file destination log

### DIFF
--- a/Sources/FileDestination.swift
+++ b/Sources/FileDestination.swift
@@ -89,6 +89,15 @@ public class FileDestination: BaseDestination {
         guard let url = logFileURL else { return false }
         do {
             if fileManager.fileExists(atPath: url.path) == false {
+                
+                let directoryURL = url.deletingLastPathComponent()
+                if fileManager.fileExists(atPath: directoryURL.path) == false {
+                    try fileManager.createDirectory(
+                        at: directoryURL,
+                        withIntermediateDirectories: true
+                    )
+                }
+                
                 // create file if not existing
                 let line = str + "\n"
                 try line.write(to: url, atomically: true, encoding: .utf8)

--- a/Tests/SwiftyBeaverTests/FileDestinationTests.swift
+++ b/Tests/SwiftyBeaverTests/FileDestinationTests.swift
@@ -99,6 +99,42 @@ class FileDestinationTests: XCTestCase {
         XCTAssertEqual(lines[2], "INFO: third line to log")
         XCTAssertEqual(lines[3], "")
     }
+    
+    func testFileIsWrittenToDeletedFolder() {
+        let log = SwiftyBeaver.self
+        
+        let path = "/tmp/\(UUID().uuidString)/testSBF.log"
+        deleteFile(path: path)
+        
+        // add file
+        let file = FileDestination()
+        file.logFileURL = URL(string: "file://" + path)!
+        file.format = "$L: $M $X"
+        _ = log.addDestination(file)
+        
+        log.verbose("first line to log")
+        log.debug("second line to log")
+        log.info("third line to log")
+        log.warning("fourth line with context", context: 123)
+        _ = log.flush(secondTimeout: 3)
+        
+        // wait a bit until the logs are written to file
+        for i in 1...100000 {
+            let x = sqrt(Double(i))
+            XCTAssertEqual(x, sqrt(Double(i)))
+        }
+        
+        // was the file written and does it contain the lines?
+        let fileLines = self.linesOfFile(path: path)
+        XCTAssertNotNil(fileLines)
+        guard let lines = fileLines else { return }
+        XCTAssertEqual(lines.count, 5)
+        XCTAssertEqual(lines[0], "VERBOSE: first line to log")
+        XCTAssertEqual(lines[1], "DEBUG: second line to log")
+        XCTAssertEqual(lines[2], "INFO: third line to log")
+        XCTAssertEqual(lines[3], "WARNING: fourth line with context 123")
+        XCTAssertEqual(lines[4], "")
+    }
 
     // MARK: Helper Functions
 


### PR DESCRIPTION
Hi.
I caught a problem in one of my projects. It has a Launch Daemon that writes logs. Over time, the logs become a lot and the user decides to clean them. But the user deletes not the files, but the whole folder with the logs. At this time, the daemon is still running, but can not write logs. I cannot handle this situation either. Only if the daemon is restarted.

Therefore, I decided to create a folder if it does not exist.