### PR TITLE
Fix broken build on Linux/Docker Swift 5.1

### DIFF
--- a/Sources/SBPlatformDestination.swift
+++ b/Sources/SBPlatformDestination.swift
@@ -9,6 +9,10 @@
 
 import Foundation
 
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
 // platform-dependent import frameworks to get device details
 // valid values for os(): OSX, iOS, watchOS, tvOS, Linux
 // in Swift 3 the following were added: FreeBSD, Windows, Android


### PR DESCRIPTION
This is required to fix builds on Linux (like in Docker),
as types like URLSession have been moved from the `Foundation`
module to the new `FoundationNetworking` module, which seems to
have diverged from Darwin and been accepted without a formal proposal
review.

Pitch: https://forums.swift.org/t/pitch-move-urlsession-to-new-foundationnetworking-module/14002
Pull Request: https://github.com/apple/swift-corelibs-foundation/pull/2289

---
This shows the problem with the code on `master` that this fixes, inside the current `swift:5.1` Docker image.
<img width="1138" alt="image" src="https://user-images.githubusercontent.com/159331/66706051-5f855c80-ecfc-11e9-90c9-41f2eb32faa1.png">
