### PR TITLE
Enabled 'Allow app extension API only' checkbox in project settings

### DIFF
--- a/SwiftyBeaver.xcodeproj/project.pbxproj
+++ b/SwiftyBeaver.xcodeproj/project.pbxproj
@@ -377,6 +377,7 @@
 		OBJ_42 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -411,6 +412,7 @@
 		OBJ_43 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
The checkbox was disabled during the project file recovery in #354. This causes Xcode warnings when app extensions link against the SwiftyBeaver framework.


> Linking against a dylib which is not safe for use in application extensions: <Project Directory>/Carthage/Build/iOS/SwiftyBeaver.framework/SwiftyBeaver