### PR TITLE
Add supported Swift versions to SwiftyBeaver.podspec

### DIFF
--- a/SwiftyBeaver.podspec
+++ b/SwiftyBeaver.podspec
@@ -23,5 +23,5 @@ Great for development & release due to its support for many logging destinations
   s.osx.deployment_target = "10.10"
   s.source       = { :git => "https://github.com/SwiftyBeaver/SwiftyBeaver.git", :tag => "1.8.3" }
   s.source_files  = "Sources"
-  s.swift_versions = ['5.0', '5.1']
+  s.swift_versions = ['3.0', '4.0', '4.2', '5.0', '5.1']
 end

--- a/SwiftyBeaver.podspec
+++ b/SwiftyBeaver.podspec
@@ -23,4 +23,5 @@ Great for development & release due to its support for many logging destinations
   s.osx.deployment_target = "10.10"
   s.source       = { :git => "https://github.com/SwiftyBeaver/SwiftyBeaver.git", :tag => "1.8.3" }
   s.source_files  = "Sources"
+  s.swift_versions = ['5.0', '5.1']
 end


### PR DESCRIPTION
Hello.
Thank you for SwiftyBeaver.
In this pull request I added supported Swift versions to SwiftyBeaver.podspec. Currently getting the following error: **- `SwiftyBeaver-iOS` does not specify a Swift version and none of the targets integrating it have the `SWIFT_VERSION` attribute set. Please contact the author or set the `SWIFT_VERSION` attribute in at least one of the targets that integrate this pod**.