### PR TITLE
Provide more human readable thread name information #376

### DIFF
--- a/Sources/SwiftyBeaver.swift
+++ b/Sources/SwiftyBeaver.swift
@@ -71,12 +71,8 @@ open class SwiftyBeaver {
             if Thread.isMainThread {
                 return ""
             } else {
-                let threadName = Thread.current.name
-                if let threadName = threadName, !threadName.isEmpty {
-                    return threadName
-                } else {
-                    return String(format: "%p", Thread.current)
-                }
+                let name = __dispatch_queue_get_label(nil)
+                return String(cString: name, encoding: .utf8) ?? Thread.current.description
             }
         #endif
     }

--- a/Tests/SwiftyBeaverTests/SwiftyBeaverTests.swift
+++ b/Tests/SwiftyBeaverTests/SwiftyBeaverTests.swift
@@ -331,6 +331,65 @@ class SwiftyBeaverTests: XCTestCase {
         XCTAssertEqual(SwiftyBeaver.stripParams(function: f), "aFunc()")
     }
 
+    func testGetCorrectThread() {
+        let log = SwiftyBeaver.self
+        let mock = MockDestination()
+        // set info level on default
+        mock.minLevel = .verbose
+        mock.asynchronously = false
+
+        log.addDestination(mock)
+
+        //main thread
+        log.verbose("Hi")
+        XCTAssertEqual(mock.didSendToThread, "")
+        log.debug("Hi")
+        XCTAssertEqual(mock.didSendToThread, "")
+        log.info("Hi")
+        XCTAssertEqual(mock.didSendToThread, "")
+        log.warning("Hi")
+        XCTAssertEqual(mock.didSendToThread, "")
+        log.error("Hi")
+        XCTAssertEqual(mock.didSendToThread, "")
+
+        var expectation = XCTestExpectation(description: "thread check")
+
+        DispatchQueue.global(qos: .background).async {
+            log.verbose("Hi")
+            XCTAssertEqual(mock.didSendToThread, "com.apple.root.background-qos")
+            log.debug("Hi")
+            XCTAssertEqual(mock.didSendToThread, "com.apple.root.background-qos")
+            log.info("Hi")
+            XCTAssertEqual(mock.didSendToThread, "com.apple.root.background-qos")
+            log.warning("Hi")
+            XCTAssertEqual(mock.didSendToThread, "com.apple.root.background-qos")
+            log.error("Hi")
+            XCTAssertEqual(mock.didSendToThread, "com.apple.root.background-qos")
+            expectation.fulfill()
+        }
+
+        self.wait(for: [expectation], timeout: 2)
+        
+        expectation = XCTestExpectation(description: "thread check custom")
+
+        DispatchQueue.init(label: "MyTestLabel").async {
+            log.verbose("Hi")
+            XCTAssertEqual(mock.didSendToThread, "MyTestLabel")
+            log.debug("Hi")
+            XCTAssertEqual(mock.didSendToThread, "MyTestLabel")
+            log.info("Hi")
+            XCTAssertEqual(mock.didSendToThread, "MyTestLabel")
+            log.warning("Hi")
+            XCTAssertEqual(mock.didSendToThread, "MyTestLabel")
+            log.error("Hi")
+            XCTAssertEqual(mock.didSendToThread, "MyTestLabel")
+            expectation.fulfill()
+        }
+
+        self.wait(for: [expectation], timeout: 2)
+
+    }
+
     static let allTests = [
         ("testAddDestination", testAddDestination),
         ("testRemoveDestination", testRemoveDestination),
@@ -343,7 +402,8 @@ class SwiftyBeaverTests: XCTestCase {
         ("testLongRunningTaskIsNotExecutedWhenLoggingUnderMinLevel",
             testLongRunningTaskIsNotExecutedWhenLoggingUnderMinLevel),
         ("testVersionAndBuild", testVersionAndBuild),
-        ("testStripParams", testStripParams)
+        ("testStripParams", testStripParams),
+        ("testGetCorrectThread", testGetCorrectThread)
     ]
 }
 
@@ -384,3 +444,4 @@ private class MockDestination: BaseDestination {
         return true
     }
 }
+


### PR DESCRIPTION
Threads are currently being named by the address and not by a more human readable name. This pull request fixes that behaviour by modifying the threadName function name the thread based on the output of __dispatch_queue_get_label. Added unit test to verify behaviour remains unchanged for the main thread and that the correct name is used for a standard global DispatchQueue and for a DispatchQueue with a custom name