### PR TITLE
Use NSFileCoordinator for thread-safe log file access

### DIFF
--- a/Sources/FileDestination.swift
+++ b/Sources/FileDestination.swift
@@ -40,9 +40,14 @@ public class FileDestination: BaseDestination {
 
     override public var defaultHashValue: Int {return 2}
     let fileManager = FileManager.default
-    var fileHandle: FileHandle?
 
-    public override init() {
+    public init(logFileURL: URL? = nil) {
+        if let logFileURL = logFileURL {
+            self.logFileURL = logFileURL
+            super.init()
+            return
+        }
+
         // platform-dependent logfile directory default
         var baseURL: URL?
         #if os(OSX)
@@ -73,7 +78,7 @@ public class FileDestination: BaseDestination {
         #endif
 
         if let baseURL = baseURL {
-            logFileURL = baseURL.appendingPathComponent("swiftybeaver.log", isDirectory: false)
+            self.logFileURL = baseURL.appendingPathComponent("swiftybeaver.log", isDirectory: false)
         }
         super.init()
     }
@@ -89,17 +94,14 @@ public class FileDestination: BaseDestination {
         return formattedString
     }
 
-    deinit {
-        // close file handle if set
-        if let fileHandle = fileHandle {
-            fileHandle.closeFile()
-        }
-    }
-
     /// appends a string as line to a file.
     /// returns boolean about success
     func saveToFile(str: String) -> Bool {
         guard let url = logFileURL else { return false }
+
+        let line = str + "\n"
+        guard let data = line.data(using: String.Encoding.utf8) else { return false }
+
         do {
             if fileManager.fileExists(atPath: url.path) == false {
                 
@@ -110,10 +112,7 @@ public class FileDestination: BaseDestination {
                         withIntermediateDirectories: true
                     )
                 }
-                
-                // create file if not existing
-                let line = str + "\n"
-                try line.write(to: url, atomically: true, encoding: .utf8)
+                fileManager.createFile(atPath: url.path, contents: nil)
 
                 #if os(iOS) || os(watchOS)
                 if #available(iOS 10.0, watchOS 3.0, *) {
@@ -122,27 +121,36 @@ public class FileDestination: BaseDestination {
                     try fileManager.setAttributes(attributes, ofItemAtPath: url.path)
                 }
                 #endif
-            } else {
-                // append to end of file
-                if fileHandle == nil {
-                    // initial setting of file handle
-                    fileHandle = try FileHandle(forWritingTo: url as URL)
-                }
-                if let fileHandle = fileHandle {
-                    _ = fileHandle.seekToEndOfFile()
-                    let line = str + "\n"
-                    if let data = line.data(using: String.Encoding.utf8) {
-                        fileHandle.write(data)
-                        if syncAfterEachWrite {
-                            fileHandle.synchronizeFile()
-                        }
-                    }
-                }
             }
+            write(data: data, to: url)
+
             return true
         } catch {
             print("SwiftyBeaver File Destination could not write to file \(url).")
             return false
+        }
+    }
+
+    private func write(data: Data, to url: URL) {
+        let coordinator = NSFileCoordinator(filePresenter: nil)
+        var error: NSError?
+        coordinator.coordinate(writingItemAt: url, error: &error) { url in
+            do {
+                let fileHandle = try FileHandle(forWritingTo: url)
+                fileHandle.seekToEndOfFile()
+                fileHandle.write(data)
+                if syncAfterEachWrite {
+                    fileHandle.synchronizeFile()
+                }
+                fileHandle.closeFile()
+            } catch {
+                print("SwiftyBeaver File Destination could not write to file \(url).")
+                return
+            }
+        }
+
+        if let error = error {
+            print("Failed writing file with error: \(String(describing: error))")
         }
     }
 
@@ -152,7 +160,6 @@ public class FileDestination: BaseDestination {
         guard let url = logFileURL, fileManager.fileExists(atPath: url.path) == true else { return true }
         do {
             try fileManager.removeItem(at: url)
-            fileHandle = nil
             return true
         } catch {
             print("SwiftyBeaver File Destination could not remove file \(url).")


### PR DESCRIPTION
This adds thread-safety to log file access.

This is particularly useful when dealing with multiple processes, e. g. when developing an iOS app that has an app extension. Due to the sandbox mechanism the default log file is distinct from the other processes' log file. By passing a custom log file url they all can log to the same file. Accessing the log file via NSFileCoordinator ensures thread-safety even across multiple processes.