### PR TITLE
Added support for macOS 10.9

### DIFF
--- a/Sources/SBPlatformDestination.swift
+++ b/Sources/SBPlatformDestination.swift
@@ -276,7 +276,9 @@ public class SBPlatformDestination: BaseDestination {
 
             // create operation queue which uses current serial queue of destination
             let operationQueue = OperationQueue()
-            operationQueue.underlyingQueue = queue
+            if #available(OSX 10.10, *) {
+                operationQueue.underlyingQueue = queue
+            }
 
             let session = URLSession(configuration:
                 URLSessionConfiguration.default,
@@ -468,11 +470,19 @@ public class SBPlatformDestination: BaseDestination {
         var details = [String: String]()
 
         details["os"] = OS
-        let osVersion = ProcessInfo.processInfo.operatingSystemVersion
-        // becomes for example 10.11.2 for El Capitan
-        var osVersionStr = String(osVersion.majorVersion)
-        osVersionStr += "." + String(osVersion.minorVersion)
-        osVersionStr += "." + String(osVersion.patchVersion)
+        
+        var osVersionStr: String
+        if #available(OSX 10.10, *) {
+            // becomes for example 10.11.2 for El Capitan
+            let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+            osVersionStr = String(osVersion.majorVersion)
+            osVersionStr += "." + String(osVersion.minorVersion)
+            osVersionStr += "." + String(osVersion.patchVersion)
+        } else {
+            // Fallback for macOS 10.9
+            osVersionStr = "10.9"
+        }
+        
         details["osVersion"] = osVersionStr
         details["hostName"] = ProcessInfo.processInfo.hostName
         details["deviceName"] = ""

--- a/SwiftyBeaver.podspec
+++ b/SwiftyBeaver.podspec
@@ -20,7 +20,7 @@ Great for development & release due to its support for many logging destinations
   s.ios.deployment_target = "8.0"
   s.watchos.deployment_target = "2.0"
   s.tvos.deployment_target = "9.0"
-  s.osx.deployment_target = "10.10"
+  s.osx.deployment_target = "10.9"
   s.source       = { :git => "https://github.com/SwiftyBeaver/SwiftyBeaver.git", :tag => "1.8.4" }
   s.source_files  = "Sources"
   s.swift_versions = ['3.0', '4.0', '4.2', '5.0', '5.1']

--- a/SwiftyBeaver.xcodeproj/project.pbxproj
+++ b/SwiftyBeaver.xcodeproj/project.pbxproj
@@ -338,7 +338,7 @@
 					"SWIFT_PACKAGE=1",
 					"DEBUG=1",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "$(inherited) -DXcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -363,7 +363,7 @@
 					"$(inherited)",
 					"SWIFT_PACKAGE=1",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				OTHER_SWIFT_FLAGS = "$(inherited) -DXcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -392,7 +392,7 @@
 				INFOPLIST_FILE = Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MARKETING_VERSION = 1.8.3;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
@@ -427,7 +427,7 @@
 				INFOPLIST_FILE = Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MARKETING_VERSION = 1.8.3;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
@@ -448,7 +448,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5";
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.9 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -457,7 +457,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5";
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.9 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;

--- a/SwiftyBeaver.xcodeproj/xcshareddata/xcschemes/SwiftyBeaver-Package.xcscheme
+++ b/SwiftyBeaver.xcodeproj/xcshareddata/xcschemes/SwiftyBeaver-Package.xcscheme
@@ -41,7 +41,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"


### PR DESCRIPTION
Hello @skreutzberger,

We would like to use your awesome logging solution in our project, but we have minimum deployment target 10.9 for macOS app. In this PR I'm just fixing compile issues for 10.9 using `#if available` Swift structure.
SPM support starts from 10.10, so this change will affect only those who uses your framework via CocoaPods or git submodules. 
Hope it makes sense.

With regards.