### PR TITLE
Removes default platform deployment targets from Package.swift file

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,12 +5,6 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftyBeaver",
-    platforms: [
-        .macOS(.v10_10),
-        .iOS(.v8),
-        .tvOS(.v9),
-        .watchOS(.v2)
-    ],
     products: [
         .library(name: "SwiftyBeaver", targets: ["SwiftyBeaver"])
     ],


### PR DESCRIPTION
This PR removes explicit deployment targets for SwiftyBeaver when using Swift Package Manager.

In Xcode 12.0 beta bumped the minimum supported deployment target to iOS 9.0. SwiftyBeaver explicitly declared iOS 8 as a minimum deployment target results in a warning/error when building SwiftUI previews.

Xcode 11 users will be unaffected as the explicitly chosen OS deployment targets are the default minimum deployment targets.