### PR TITLE
Workaround for Xcode12 build error

### DIFF
--- a/Sources/BaseDestination.swift
+++ b/Sources/BaseDestination.swift
@@ -145,8 +145,8 @@ open class BaseDestination: Hashable, Equatable {
         } else {
             s = text
         }
-        let numStr = s.prefix { $0 >= "0" && $0 <= "9" }
-        if let num = Int(String(numStr)) {
+        let numStr = String(s.prefix { $0 >= "0" && $0 <= "9" })
+        if let num = Int(numStr) {
             return (sign * num, (sign == -1 ? 1 : 0) + numStr.count)
         } else {
             return (0, 0)

--- a/Sources/Filter.swift
+++ b/Sources/Filter.swift
@@ -18,7 +18,7 @@ import Foundation
 /// A filter can be required meaning that all required filters against a specific
 /// target must pass in order for the message to be logged.
 public protocol FilterType : class {
-    func apply(_ value: Any) -> Bool
+    func apply(_ value: String?) -> Bool
     func getTarget() -> Filter.TargetType
     func isRequired() -> Bool
     func isExcluded() -> Bool
@@ -105,8 +105,8 @@ public class CompareFilter: Filter, FilterType {
         self.filterComparisonType = comparisonType
     }
 
-    public func apply(_ value: Any) -> Bool {
-        guard let value = value as? String else {
+    public func apply(_ value: String?) -> Bool {
+        guard let value = value else {
             return false
         }
 


### PR DESCRIPTION
This is a workaround for this issue.

 - iOS 14 support #409

The problem seems to be caused by a bug in Xcode12 beta related to String type inference.

Undefined symbol: type metadata for Swift._StringObject.Variant
https://developer.apple.com/forums/thread/649918

This problem is also reproduced in beta 1 and beta 2.

This fix in this pull request may seem useless as it does not affect the behavior of this SDK.
But it will help developers who use Xcode 12 beta.