### PR TITLE
Allow subclassing of FileDestination

### DIFF
--- a/Sources/FileDestination.swift
+++ b/Sources/FileDestination.swift
@@ -9,7 +9,7 @@
 
 import Foundation
 
-public class FileDestination: BaseDestination {
+public open class FileDestination: BaseDestination {
 
     public var logFileURL: URL?
     public var syncAfterEachWrite: Bool = false


### PR DESCRIPTION
I would like to pre-process the message that goes to a certain file location. For that, I would like to subclass the `FileDestination` and overwrite `send` to process the message before passing it to the super class.