### PR TITLE
AWS CloudWatch support for iOS 

### DIFF
--- a/Sources/CloudWatch/AWSCloudWatchDestination.swift
+++ b/Sources/CloudWatch/AWSCloudWatchDestination.swift
@@ -23,7 +23,7 @@ public class AWSCloudWatchDestination: BaseDestination {
         
         logEvents.add(message: jsonString)
         
-        if ((logEvents.events.count >= 2 || (logEvents.events.count > 0 &&
+        if ((logEvents.events.count >= 10 || (logEvents.events.count > 0 &&
             Date().timeIntervalSince1970 - lastSend > 15.0)) && !sendInProgress) {
            sendEvents()
         } else {

--- a/Sources/CloudWatch/AWSCloudWatchDestination.swift
+++ b/Sources/CloudWatch/AWSCloudWatchDestination.swift
@@ -1,0 +1,70 @@
+//
+//  AWSCloudWatchDestination.swift
+//  SwiftyBeaver/CloudWatch
+//
+
+#if CLOUD_WATCH
+
+public class AWSCloudWatchDestination: BaseDestination {
+    public private(set) var logStream: CloudWatchLogStream! = nil
+    private var logEvents: CloudWatchLogEvents = CloudWatchLogEvents()
+    private var lastSend = Date().timeIntervalSince1970
+    private var flushTimer = false
+    private var sendInProgress = false
+    
+    public init(logStream: CloudWatchLogStream) {
+        self.logStream = logStream
+    }
+    
+    override public func send(_ level: SwiftyBeaver.Level, msg: String, thread: String,
+            file: String, function: String, line: Int, context: Any? = nil) -> String? {
+
+        let jsonString = "{\"level\":\"\(level)\",\"message\":\"\(msg)\",\"function\":\"\(function)\",\"fileName\":\"\(file.components(separatedBy: "/").last!)\",\"line\":\(line)}"
+        
+        logEvents.add(message: jsonString)
+        
+        if ((logEvents.events.count >= 2 || (logEvents.events.count > 0 &&
+            Date().timeIntervalSince1970 - lastSend > 15.0)) && !sendInProgress) {
+           sendEvents()
+        } else {
+            if (!flushTimer) {
+                flushTimer = true
+                DispatchQueue.main.asyncAfter(deadline: .now() + 10.0) {
+                    self.sendEvents()
+                    self.flushTimer = false
+                }
+            }
+        }
+        
+        return jsonString
+    }
+    
+    private func sendEvents() {
+        sendInProgress = true
+        execute(synchronously: false) {
+            let dg = DispatchGroup()
+            dg.enter()
+            
+            if (self.logEvents.events.count == 0) {
+                self.sendInProgress = false
+                dg.leave()
+                return
+            }
+            
+            self.logStream.sendEvents(events: self.logEvents) { (error, rejectedEventsInfo) in
+                if let error = error {
+                    print("An error occurred sending log events to AWS log stream. \(error)")
+                }
+                
+                self.logEvents = CloudWatchLogEvents()
+                self.lastSend = Date().timeIntervalSince1970
+                self.sendInProgress = false
+                dg.leave()
+            }
+            dg.wait()
+        }
+    }
+        
+}
+
+#endif

--- a/Sources/CloudWatch/AWSServiceConfig.swift
+++ b/Sources/CloudWatch/AWSServiceConfig.swift
@@ -1,0 +1,30 @@
+//
+//  AWSServiceConfig.swift
+//  SwiftyBeaver/CloudWatch
+//
+
+#if CLOUD_WATCH
+
+import Foundation
+import AWSCore
+
+open class AWSServiceConfig {
+    public let cognitoPoolId: String
+    public let regionType: AWSRegionType
+    open var configuration: AWSServiceConfiguration! = nil
+    
+    public init(cognitoPoolId: String, regionType: AWSRegionType) {
+        self.cognitoPoolId = cognitoPoolId
+        self.regionType = regionType
+    }
+    
+    open func create() -> AWSServiceConfig {
+        let credentialsProvider = AWSCognitoCredentialsProvider(regionType:self.regionType,
+                identityPoolId: cognitoPoolId)
+        configuration = AWSServiceConfiguration(region:self.regionType, credentialsProvider:credentialsProvider)
+        AWSServiceManager.default().defaultServiceConfiguration = configuration
+        return self
+    }
+}
+
+#endif

--- a/Sources/CloudWatch/CloudWatchLogEvents.swift
+++ b/Sources/CloudWatch/CloudWatchLogEvents.swift
@@ -1,0 +1,30 @@
+//
+//  CloudWatchLogEvents.swift
+//  SwiftyBeaver/CloudWatch
+//
+
+#if CLOUD_WATCH
+
+import Foundation
+import AWSLogs
+
+public class CloudWatchLogEvents {
+    public let request = AWSLogsPutLogEventsRequest()!
+    
+    public init() {
+        request.logEvents = []
+    }
+    
+    public var events: [AWSLogsInputLogEvent] {
+        return request.logEvents!
+    }
+    
+    public func add(message: String) {
+        let event = AWSLogsInputLogEvent()!
+        event.message = message
+        event.timestamp = NSNumber(value: Date().timeIntervalSince1970 * 1000)
+        request.logEvents?.append(event)
+    }
+}
+
+#endif

--- a/Sources/CloudWatch/CloudWatchLogGroup.swift
+++ b/Sources/CloudWatch/CloudWatchLogGroup.swift
@@ -1,0 +1,18 @@
+//
+//  CloudWatchLogGroup.swift
+//  SwiftyBeaver/CloudWatch
+//
+
+#if CLOUD_WATCH
+
+import Foundation
+
+public class CloudWatchLogGroup {
+    public let name: String
+    
+    public init(name: String) {
+        self.name = name
+    }
+}
+
+#endif

--- a/Sources/CloudWatch/CloudWatchLogStream.swift
+++ b/Sources/CloudWatch/CloudWatchLogStream.swift
@@ -1,0 +1,50 @@
+//
+//  CloudWatchLogStream.swift
+//  SwiftyBeaver/CloudWatch
+//
+
+#if CLOUD_WATCH
+
+import Foundation
+import AWSLogs
+
+public class CloudWatchLogStream {
+    public let name: String
+    public let group: CloudWatchLogGroup
+    private let logs: CloudWatchLogs
+    private var cloudWatchSequenceToken: String?
+    
+    public init(cloudWatchLogs: CloudWatchLogs, group: CloudWatchLogGroup, name: String) {
+        self.name = name
+        self.group = group
+        self.logs = cloudWatchLogs
+    }
+    
+    public func create(completion: @escaping (Error?) -> Void) {
+        let logStreamRequest = AWSLogsCreateLogStreamRequest()!
+        logStreamRequest.logGroupName = group.name
+        logStreamRequest.logStreamName = name
+        logs.createLogStream(logStreamRequest) { error in
+            completion(error)
+        }
+    }
+    
+    public func sendEvents(events: CloudWatchLogEvents, completion: @escaping (Error?, AWSLogsRejectedLogEventsInfo?) -> Void) {
+        let request = events.request
+        request.logGroupName = group.name
+        request.logStreamName = name
+        request.sequenceToken = cloudWatchSequenceToken
+        
+        logs.putLogEvents(request) { resp, error in
+            if let error = error {
+                print("An error occurred putting the log events \(error)")
+            }
+            if let token = resp?.nextSequenceToken {
+                self.cloudWatchSequenceToken = token
+            }
+            completion(error, resp?.rejectedLogEventsInfo)
+        }
+    }
+}
+
+#endif

--- a/Sources/CloudWatch/CloudWatchLogs.swift
+++ b/Sources/CloudWatch/CloudWatchLogs.swift
@@ -1,0 +1,40 @@
+//
+//  CloudWatchLogs.swift
+//  SwiftyBeaver/CloudWatch
+//
+
+#if CLOUD_WATCH
+
+import Foundation
+import AWSLogs
+
+open class CloudWatchLogs {
+    public let clientKey: String
+    public let configuration: AWSServiceConfiguration
+    public var logs: AWSLogs! = nil
+    
+    public init(config: AWSServiceConfig, clientKey: String) {
+        self.configuration = config.configuration
+        self.clientKey = clientKey
+    }
+    
+    open func initialize() -> CloudWatchLogs {
+        AWSLogs.register(with: configuration, forKey: clientKey)
+        logs = AWSLogs.init(forKey: clientKey)
+        return self
+    }
+    
+    open func createLogStream(_ request: AWSLogsCreateLogStreamRequest, completionHandler: ((Error?) -> Void)?) {
+        logs.createLogStream(request) { error in
+            completionHandler?(error)
+        }
+    }
+    
+    open func putLogEvents(_ request: AWSLogsPutLogEventsRequest, completionHandler: ((AWSLogsPutLogEventsResponse?, Error?) -> Void)?) {
+        logs.putLogEvents(request) { resp, error in
+            completionHandler?(resp, error)
+        }
+    }
+}
+
+#endif

--- a/Sources/CloudWatch/README.md
+++ b/Sources/CloudWatch/README.md
@@ -2,7 +2,7 @@
 
 SwiftyBeaver/CloudWatch cocoapods subspec creates a SwiftyBeaver log destination for AWS Cloudwatch.
 
-###NOTE: AWS CloudWatch cocoapod dependencies do *not* support tvos, watchos, or macos at this time.
+### NOTE: AWS CloudWatch cocoapod dependencies do *not* support tvos, watchos, or macos at this time.
 ### This POD subspec currently *only* supports iOS and only Cocoapods package manager.
 
 ## Installation

--- a/Sources/CloudWatch/README.md
+++ b/Sources/CloudWatch/README.md
@@ -14,7 +14,7 @@ pod 'SwiftyBeaver/CloudWatch'
 
 Note that other Swift package managers are not supported for this subspec.
 
-##Usage
+## Usage
 
 To create a log destination for AWS Cloudwatch on iOS you must use the included class wrappers to authenticate to AWS using  Cognito Identity pool, and either create a log stream or use a log stream which is already created in your AWS account.
 

--- a/Sources/CloudWatch/README.md
+++ b/Sources/CloudWatch/README.md
@@ -1,0 +1,47 @@
+# SwiftyBeaver/CloudWatch
+
+SwiftyBeaver/CloudWatch cocoapods subspec creates a SwiftyBeaver log destination for AWS Cloudwatch.
+
+###NOTE: AWS CloudWatch cocoapod dependencies do *not* support tvos, watchos, or macos at this time.
+### This POD subspec currently *only* supports iOS and only Cocoapods package manager.
+
+## Installation
+
+Swift 4 & 5 (Cocoapods):
+``` Swift
+pod 'SwiftyBeaver/CloudWatch'
+```
+
+Note that other Swift package managers are not supported for this subspec.
+
+##Usage
+
+To create a log destination for AWS Cloudwatch on iOS you must use the included class wrappers to authenticate to AWS using  Cognito Identity pool, and either create a log stream or use a log stream which is already created in your AWS account.
+
+While there are a few ways to do this, the wrapper currently supports unauthenticated Cognito Identity Pool access.  See AWS documentation on how to use Cognito Identity Pools and how to setup your IAM role for the identity pool properly to access CloudWatch resources.
+
+Here is an example of setting up the SwiftyBeaver destination for AWS CloudWatch.
+
+``` Swift
+
+//Note that since a log stream is being created asynchronously, no logging should occur in the app until
+//the completion block is invoked.
+
+func initializeLog(completion: @escaping () -> Void) {
+    let serviceConfig = AWSServiceConfig(cognitoPoolId: "somePoolId", regionType: .USWest1).create()
+    let cloudWatchLogs = CloudWatchLogs(config: serviceConfig, clientKey: "someClientKey")
+    let group = CloudWatchLogGroup(name: "/my/log/group/name")
+    let cloudWatchStream = CloudWatchLogStream(cloudWatchLogs: cloudWatchLogs, group: cloudWatchLogGroup, name: "/my/Log/stream/name")
+
+    cloudWatchLogStream.create() { error in
+        //add the SwiftyBeaver log destinations.. (log has been setup as in the SwiftyBeaver docs)
+        self.log.addDestination(ConsoleDestination())
+        self.log.addDestination(AWSCloudWatchDestination(logStream: cloudWatchLogStream))
+        DispatchQueue.main.async {
+            completion()
+        }
+    }
+}
+
+```
+

--- a/Sources/CloudWatch/README.md
+++ b/Sources/CloudWatch/README.md
@@ -29,7 +29,7 @@ Here is an example of setting up the SwiftyBeaver destination for AWS CloudWatch
 
 func initializeLog(completion: @escaping () -> Void) {
     let serviceConfig = AWSServiceConfig(cognitoPoolId: "somePoolId", regionType: .USWest1).create()
-    let cloudWatchLogs = CloudWatchLogs(config: serviceConfig, clientKey: "someClientKey")
+    let cloudWatchLogs = CloudWatchLogs(config: serviceConfig, clientKey: "someClientKey").initialize()
     let group = CloudWatchLogGroup(name: "/my/log/group/name")
     let cloudWatchStream = CloudWatchLogStream(cloudWatchLogs: cloudWatchLogs, group: cloudWatchLogGroup, name: "/my/Log/stream/name")
 

--- a/SwiftyBeaver.podspec
+++ b/SwiftyBeaver.podspec
@@ -21,7 +21,40 @@ Great for development & release due to its support for many logging destinations
   s.watchos.deployment_target = "2.0"
   s.tvos.deployment_target = "9.0"
   s.osx.deployment_target = "10.10"
-  s.source       = { :git => "https://github.com/SwiftyBeaver/SwiftyBeaver.git", :tag => "1.9.3" }
+  s.source       = { :git => "https://github.com/smileatom/SwiftyBeaver.git" }
   s.source_files  = "Sources"
   s.swift_versions = ['4.0', '4.2', '5.0', '5.1']
+  s.default_subspec = 'Lite'
+
+  s.subspec 'Lite' do |lite|
+  # used to exclude additional dependencies by default
+    lite.source_files = "Sources"
+  end
+  
+  s.subspec 'CloudWatch' do |cloudwatch|
+    cloudwatch.platform= :ios, '9.0'
+    cloudwatch.source_files = "Sources", "Sources/CloudWatch"
+    cloudwatch.xcconfig    =
+        { 'OTHER_SWIFT_FLAGS' => '$(inherited) -DCLOUD_WATCH' }
+    cloudwatch.dependency    'AWSCore'
+    cloudwatch.dependency    'AWSLogs'
+    
+    cloudwatch.test_spec 'CloudWatchTests' do |test_spec|
+        test_spec.source_files = 'Tests/SwiftyBeaverTests/CloudWatch/CloudWatchLogGroupTests.swift',
+            'Tests/SwiftyBeaverTests/CloudWatch/AAWSServiceConfigTests.swift',
+            'Tests/SwiftyBeaverTests/CloudWatch/CloudWatchLogEventsTests.swift',
+            'Tests/SwiftyBeaverTests/CloudWatch/mocks/AWSServiceConfigMock.swift',
+            'Tests/SwiftyBeaverTests/CloudWatch/mocks/CloudWatchLogsMock.swift',
+            'Tests/SwiftyBeaverTests/CloudWatch/CloudWatchLogStreamTests.swift',
+            'Tests/SwiftyBeaverTests/CloudWatch/CloudWatchLogsTests.swift',
+            'Tests/SwiftyBeaverTests/CloudWatch/AWSCloudWatchDestinationTests.swift'
+        
+        test_spec.dependency 'AWSCore'
+        test_spec.dependency 'AWSLogs'
+
+        test_spec.xcconfig    =
+            { 'OTHER_SWIFT_FLAGS' => '$(inherited) -DCLOUD_WATCH' }
+    end
+  end
+  
 end

--- a/SwiftyBeaver.xcodeproj/project.pbxproj
+++ b/SwiftyBeaver.xcodeproj/project.pbxproj
@@ -21,6 +21,20 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		A9B5CB3225FD7D4000B2915B /* AWSCloudWatchDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B5CB2C25FD7D4000B2915B /* AWSCloudWatchDestination.swift */; };
+		A9B5CB3325FD7D4000B2915B /* CloudWatchLogStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B5CB2D25FD7D4000B2915B /* CloudWatchLogStream.swift */; };
+		A9B5CB3425FD7D4000B2915B /* CloudWatchLogs.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B5CB2E25FD7D4000B2915B /* CloudWatchLogs.swift */; };
+		A9B5CB3525FD7D4000B2915B /* CloudWatchLogGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B5CB2F25FD7D4000B2915B /* CloudWatchLogGroup.swift */; };
+		A9B5CB3625FD7D4000B2915B /* AWSServiceConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B5CB3025FD7D4000B2915B /* AWSServiceConfig.swift */; };
+		A9B5CB3725FD7D4000B2915B /* CloudWatchLogEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B5CB3125FD7D4000B2915B /* CloudWatchLogEvents.swift */; };
+		A9B5CB4625FD7D4D00B2915B /* AWSServiceConfigMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B5CB3E25FD7D4D00B2915B /* AWSServiceConfigMock.swift */; };
+		A9B5CB4725FD7D4D00B2915B /* CloudWatchLogsMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B5CB3F25FD7D4D00B2915B /* CloudWatchLogsMock.swift */; };
+		A9B5CB4825FD7D4D00B2915B /* AAWSServiceConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B5CB4025FD7D4D00B2915B /* AAWSServiceConfigTests.swift */; };
+		A9B5CB4925FD7D4D00B2915B /* CloudWatchLogEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B5CB4125FD7D4D00B2915B /* CloudWatchLogEventsTests.swift */; };
+		A9B5CB4A25FD7D4D00B2915B /* CloudWatchLogStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B5CB4225FD7D4D00B2915B /* CloudWatchLogStreamTests.swift */; };
+		A9B5CB4B25FD7D4D00B2915B /* CloudWatchLogsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B5CB4325FD7D4D00B2915B /* CloudWatchLogsTests.swift */; };
+		A9B5CB4C25FD7D4D00B2915B /* AWSCloudWatchDestinationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B5CB4425FD7D4D00B2915B /* AWSCloudWatchDestinationTests.swift */; };
+		A9B5CB4D25FD7D4D00B2915B /* CloudWatchLogGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B5CB4525FD7D4D00B2915B /* CloudWatchLogGroupTests.swift */; };
 		OBJ_45 /* AES256CBC.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_8 /* AES256CBC.swift */; };
 		OBJ_46 /* Base64.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* Base64.swift */; };
 		OBJ_47 /* BaseDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* BaseDestination.swift */; };
@@ -64,6 +78,22 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A9B5CB2C25FD7D4000B2915B /* AWSCloudWatchDestination.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSCloudWatchDestination.swift; sourceTree = "<group>"; };
+		A9B5CB2D25FD7D4000B2915B /* CloudWatchLogStream.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudWatchLogStream.swift; sourceTree = "<group>"; };
+		A9B5CB2E25FD7D4000B2915B /* CloudWatchLogs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudWatchLogs.swift; sourceTree = "<group>"; };
+		A9B5CB2F25FD7D4000B2915B /* CloudWatchLogGroup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudWatchLogGroup.swift; sourceTree = "<group>"; };
+		A9B5CB3025FD7D4000B2915B /* AWSServiceConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSServiceConfig.swift; sourceTree = "<group>"; };
+		A9B5CB3125FD7D4000B2915B /* CloudWatchLogEvents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudWatchLogEvents.swift; sourceTree = "<group>"; };
+		A9B5CB3E25FD7D4D00B2915B /* AWSServiceConfigMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSServiceConfigMock.swift; sourceTree = "<group>"; };
+		A9B5CB3F25FD7D4D00B2915B /* CloudWatchLogsMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudWatchLogsMock.swift; sourceTree = "<group>"; };
+		A9B5CB4025FD7D4D00B2915B /* AAWSServiceConfigTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AAWSServiceConfigTests.swift; sourceTree = "<group>"; };
+		A9B5CB4125FD7D4D00B2915B /* CloudWatchLogEventsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudWatchLogEventsTests.swift; sourceTree = "<group>"; };
+		A9B5CB4225FD7D4D00B2915B /* CloudWatchLogStreamTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudWatchLogStreamTests.swift; sourceTree = "<group>"; };
+		A9B5CB4325FD7D4D00B2915B /* CloudWatchLogsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudWatchLogsTests.swift; sourceTree = "<group>"; };
+		A9B5CB4425FD7D4D00B2915B /* AWSCloudWatchDestinationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSCloudWatchDestinationTests.swift; sourceTree = "<group>"; };
+		A9B5CB4525FD7D4D00B2915B /* CloudWatchLogGroupTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudWatchLogGroupTests.swift; sourceTree = "<group>"; };
+		A9B5CB5225FD836300B2915B /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		A9B5CB5325FD83C600B2915B /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		OBJ_10 /* BaseDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseDestination.swift; sourceTree = "<group>"; };
 		OBJ_11 /* ConsoleDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleDestination.swift; sourceTree = "<group>"; };
 		OBJ_12 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
@@ -115,6 +145,44 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		A9B5CB2B25FD7D4000B2915B /* CloudWatch */ = {
+			isa = PBXGroup;
+			children = (
+				A9B5CB5225FD836300B2915B /* README.md */,
+				A9B5CB2C25FD7D4000B2915B /* AWSCloudWatchDestination.swift */,
+				A9B5CB2D25FD7D4000B2915B /* CloudWatchLogStream.swift */,
+				A9B5CB2E25FD7D4000B2915B /* CloudWatchLogs.swift */,
+				A9B5CB2F25FD7D4000B2915B /* CloudWatchLogGroup.swift */,
+				A9B5CB3025FD7D4000B2915B /* AWSServiceConfig.swift */,
+				A9B5CB3125FD7D4000B2915B /* CloudWatchLogEvents.swift */,
+			);
+			path = CloudWatch;
+			sourceTree = "<group>";
+		};
+		A9B5CB3C25FD7D4D00B2915B /* CloudWatch */ = {
+			isa = PBXGroup;
+			children = (
+				A9B5CB5325FD83C600B2915B /* README.md */,
+				A9B5CB3D25FD7D4D00B2915B /* mocks */,
+				A9B5CB4025FD7D4D00B2915B /* AAWSServiceConfigTests.swift */,
+				A9B5CB4425FD7D4D00B2915B /* AWSCloudWatchDestinationTests.swift */,
+				A9B5CB4125FD7D4D00B2915B /* CloudWatchLogEventsTests.swift */,
+				A9B5CB4325FD7D4D00B2915B /* CloudWatchLogsTests.swift */,
+				A9B5CB4525FD7D4D00B2915B /* CloudWatchLogGroupTests.swift */,
+				A9B5CB4225FD7D4D00B2915B /* CloudWatchLogStreamTests.swift */,
+			);
+			path = CloudWatch;
+			sourceTree = "<group>";
+		};
+		A9B5CB3D25FD7D4D00B2915B /* mocks */ = {
+			isa = PBXGroup;
+			children = (
+				A9B5CB3E25FD7D4D00B2915B /* AWSServiceConfigMock.swift */,
+				A9B5CB3F25FD7D4D00B2915B /* CloudWatchLogsMock.swift */,
+			);
+			path = mocks;
+			sourceTree = "<group>";
+		};
 		OBJ_19 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -126,6 +194,7 @@
 		OBJ_20 /* SwiftyBeaverTests */ = {
 			isa = PBXGroup;
 			children = (
+				A9B5CB3C25FD7D4D00B2915B /* CloudWatch */,
 				OBJ_21 /* AES256CBCTests.swift */,
 				OBJ_22 /* BaseDestinationTests.swift */,
 				OBJ_23 /* ConsoleDestinationTests.swift */,
@@ -169,6 +238,7 @@
 		OBJ_7 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				A9B5CB2B25FD7D4000B2915B /* CloudWatch */,
 				OBJ_8 /* AES256CBC.swift */,
 				OBJ_9 /* Base64.swift */,
 				OBJ_10 /* BaseDestination.swift */,
@@ -268,16 +338,30 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				A9B5CB4D25FD7D4D00B2915B /* CloudWatchLogGroupTests.swift in Sources */,
+				A9B5CB4725FD7D4D00B2915B /* CloudWatchLogsMock.swift in Sources */,
+				A9B5CB3525FD7D4000B2915B /* CloudWatchLogGroup.swift in Sources */,
 				OBJ_45 /* AES256CBC.swift in Sources */,
 				OBJ_46 /* Base64.swift in Sources */,
+				A9B5CB3625FD7D4000B2915B /* AWSServiceConfig.swift in Sources */,
+				A9B5CB3425FD7D4000B2915B /* CloudWatchLogs.swift in Sources */,
 				OBJ_47 /* BaseDestination.swift in Sources */,
+				A9B5CB3325FD7D4000B2915B /* CloudWatchLogStream.swift in Sources */,
+				A9B5CB4B25FD7D4D00B2915B /* CloudWatchLogsTests.swift in Sources */,
 				OBJ_48 /* ConsoleDestination.swift in Sources */,
+				A9B5CB4825FD7D4D00B2915B /* AAWSServiceConfigTests.swift in Sources */,
 				OBJ_49 /* Extensions.swift in Sources */,
+				A9B5CB4625FD7D4D00B2915B /* AWSServiceConfigMock.swift in Sources */,
 				OBJ_50 /* FileDestination.swift in Sources */,
 				OBJ_51 /* Filter.swift in Sources */,
 				OBJ_52 /* FilterValidator.swift in Sources */,
+				A9B5CB3225FD7D4000B2915B /* AWSCloudWatchDestination.swift in Sources */,
+				A9B5CB4A25FD7D4D00B2915B /* CloudWatchLogStreamTests.swift in Sources */,
 				OBJ_53 /* GoogleCloudDestination.swift in Sources */,
+				A9B5CB4925FD7D4D00B2915B /* CloudWatchLogEventsTests.swift in Sources */,
+				A9B5CB4C25FD7D4D00B2915B /* AWSCloudWatchDestinationTests.swift in Sources */,
 				OBJ_54 /* SBPlatformDestination.swift in Sources */,
+				A9B5CB3725FD7D4000B2915B /* CloudWatchLogEvents.swift in Sources */,
 				OBJ_55 /* SwiftyBeaver.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/SwiftyBeaverTests/CloudWatch/AAWSServiceConfigTests.swift
+++ b/Tests/SwiftyBeaverTests/CloudWatch/AAWSServiceConfigTests.swift
@@ -1,0 +1,47 @@
+//
+//  AWSServiceConfigTests.swift
+//  SwiftyBeaver/CloudWatch
+//
+
+#if CLOUD_WATCH
+
+import Foundation
+import XCTest
+import AWSCore
+
+@testable import SwiftyBeaver
+
+//intentionally mispelled so this test runs first
+class AAWSServiceConfigTests: XCTestCase {
+    var serviceConfig: AWSServiceConfig! = nil
+
+    override func setUp() {
+        super.setUp()
+        serviceConfig = AWSServiceConfig(cognitoPoolId: "12345", regionType: .USWest2)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testInit() {
+        XCTAssertEqual(serviceConfig.cognitoPoolId, "12345")
+        XCTAssertEqual(serviceConfig.regionType, .USWest2)
+    }
+    
+    func testCreate() {
+        _ = serviceConfig.create()
+        XCTAssertNotNil(AWSServiceManager.default().defaultServiceConfiguration)
+        XCTAssertEqual(AWSServiceManager.default().defaultServiceConfiguration.regionType, .USWest2)
+        XCTAssertNotNil(AWSServiceManager.default().defaultServiceConfiguration.credentialsProvider)
+        XCTAssertEqual((AWSServiceManager.default().defaultServiceConfiguration.credentialsProvider as! AWSCognitoCredentialsProvider).identityPoolId, "12345")
+    }
+
+    static var allTests = [
+        ("testInit", testInit),
+        ("testCreate", testCreate)
+    ]
+
+}
+
+#endif

--- a/Tests/SwiftyBeaverTests/CloudWatch/AWSCloudWatchDestinationTests.swift
+++ b/Tests/SwiftyBeaverTests/CloudWatch/AWSCloudWatchDestinationTests.swift
@@ -1,0 +1,66 @@
+//
+//  AWSCloudWatchDestinationTests.swift
+//  SwiftyBeaver/CloudWatch
+//
+
+#if CLOUD_WATCH
+
+import Foundation
+import XCTest
+import AWSCore
+@testable import SwiftyBeaver
+
+class AWSCloudWatchDestinationTests: XCTestCase {
+    var destination: AWSCloudWatchDestination! = nil
+    var logs: CloudWatchLogsMock! = nil
+    var group: CloudWatchLogGroup! = nil
+    var logStream: CloudWatchLogStream! = nil
+
+    override func setUp() {
+        super.setUp()
+        group = CloudWatchLogGroup(name: "/my/log/group")
+        let config = AWSServiceConfigMock(cognitoPoolId: "12345", regionType: .USWest2).create()
+        logs = CloudWatchLogsMock(config: config, clientKey: "myClientKey").initialize()
+        logStream = CloudWatchLogStream(cloudWatchLogs: logs, group: group, name: "/my/stream/name")
+        destination = AWSCloudWatchDestination(logStream: logStream)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testInit() {
+        XCTAssertNotNil(destination.logStream)
+    }
+    
+    func testSend() {
+        let message = destination.send(.debug, msg: "This is a log message", thread: "",
+                         file: "AWSCloudWatchDestinationTests", function: "testSend", line: 38, context: nil)
+        
+        XCTAssertEqual(message!, "{\"level\":\"debug\",\"message\":\"This is a log message\",\"function\":\"testSend\",\"fileName\":\"AWSCloudWatchDestinationTests\",\"line\":38}")
+        
+        let expectation = self.expectation(description: "foo")
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 11.0) {
+            XCTAssertTrue(self.logs.putEventsCalled)
+            XCTAssertNotNil(self.logs.putEventsRequest!)
+            XCTAssertEqual(self.logs.putEventsRequest?.logGroupName, self.group.name)
+            XCTAssertEqual(self.logs.putEventsRequest?.logStreamName, self.logStream.name)
+            XCTAssertEqual(self.logs.putEventsRequest?.logEvents?.count,1)
+            XCTAssertEqual(self.logs.putEventsRequest?.logEvents?[0].message, "{\"level\":\"debug\",\"message\":\"This is a log message\",\"function\":\"testSend\",\"fileName\":\"AWSCloudWatchDestinationTests\",\"line\":38}")
+            XCTAssertNotNil(self.logs.putEventsRequest?.logEvents?[0].timestamp)
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 15.0)
+    }
+
+   
+    static var allTests = [
+        ("testInit", testInit),
+        ("testSend", testSend)
+    ]
+
+}
+
+#endif

--- a/Tests/SwiftyBeaverTests/CloudWatch/CloudWatchLogEventsTests.swift
+++ b/Tests/SwiftyBeaverTests/CloudWatch/CloudWatchLogEventsTests.swift
@@ -1,0 +1,52 @@
+//
+//  CloudWatchLogEventsTests.swift
+//  SwiftyBeaver/CloudWatch
+//
+
+#if CLOUD_WATCH
+
+import Foundation
+import XCTest
+@testable import SwiftyBeaver
+
+class CloudWatchLogEventsTests: XCTestCase {
+    var logEvents: CloudWatchLogEvents! = nil
+
+    override func setUp() {
+        super.setUp()
+        logEvents = CloudWatchLogEvents()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testInit() {
+        XCTAssertNotNil(logEvents.request)
+        XCTAssertEqual(logEvents.request.logEvents, [])
+    }
+    
+    func testEvents() {
+        XCTAssertEqual(logEvents.events, [])
+    }
+    
+    func testAdd() {
+        logEvents.add(message: "This is a log message")
+        logEvents.add(message: "This is another log message")
+        
+        XCTAssertEqual(logEvents.events.count,2)
+        XCTAssertEqual(logEvents.events[0].message, "This is a log message")
+        XCTAssertNotNil(logEvents.events[0].timestamp)
+        XCTAssertEqual(logEvents.events[1].message, "This is another log message")
+        XCTAssertNotNil(logEvents.events[1].timestamp)
+    }
+
+    static var allTests = [
+        ("testInit", testInit),
+        ("testEvents", testEvents),
+        ("testAdd", testAdd)
+    ]
+
+}
+
+#endif

--- a/Tests/SwiftyBeaverTests/CloudWatch/CloudWatchLogGroupTests.swift
+++ b/Tests/SwiftyBeaverTests/CloudWatch/CloudWatchLogGroupTests.swift
@@ -1,0 +1,35 @@
+//
+//  CloudWatchLogGroupTests.swift
+//  SwiftyBeaver/CloudWatch
+//
+
+#if CLOUD_WATCH
+
+import Foundation
+import XCTest
+@testable import SwiftyBeaver
+
+class CloudWatchLogGroupTests: XCTestCase {
+    var group: CloudWatchLogGroup! = nil
+
+    override func setUp() {
+        super.setUp()
+        group = CloudWatchLogGroup(name: "/my/log/group")
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testInit() {
+        XCTAssertEqual(group.name, "/my/log/group")
+    }
+
+   
+    static var allTests = [
+        ("testInit", testInit)
+    ]
+
+}
+
+#endif

--- a/Tests/SwiftyBeaverTests/CloudWatch/CloudWatchLogStreamTests.swift
+++ b/Tests/SwiftyBeaverTests/CloudWatch/CloudWatchLogStreamTests.swift
@@ -1,0 +1,78 @@
+//
+//  CloudWatchLogStreamTests.swift
+//  SwiftyBeaver/CloudWatch
+//
+
+#if CLOUD_WATCH
+
+import Foundation
+import XCTest
+import AWSLogs
+
+@testable import SwiftyBeaver
+
+class CloudWatchLogStreamTests: XCTestCase {
+    var group: CloudWatchLogGroup! = nil
+    var config: AWSServiceConfigMock! = nil
+    var logs: CloudWatchLogsMock! = nil
+    var logStream: CloudWatchLogStream! = nil
+    
+    override func setUp() {
+        super.setUp()
+        group = CloudWatchLogGroup(name: "/my/log/group")
+        config = AWSServiceConfigMock(cognitoPoolId: "12345", regionType: .USWest2).create()
+        logs = CloudWatchLogsMock(config: config, clientKey: "myClientKey").initialize()
+        logStream = CloudWatchLogStream(cloudWatchLogs: logs, group: group, name: "/my/stream/name")
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testInit() {
+        XCTAssertEqual(logStream.name, "/my/stream/name")
+        XCTAssertNotNil(logStream.group)
+        XCTAssertEqual(logStream.group.name, group.name)
+    }
+    
+    func testCreate() {
+        logStream.create() { error in
+            XCTAssertNil(error)
+        }
+        
+        XCTAssertTrue(logs.createLogStreamCalled)
+        XCTAssertNotNil(logs.createStreamRequest!)
+        XCTAssertEqual(logs.createStreamRequest?.logGroupName, group.name)
+        XCTAssertEqual(logs.createStreamRequest?.logStreamName, logStream.name)
+    }
+    
+    func testSendEvents() {
+        let logEvents = CloudWatchLogEvents()
+        logEvents.add(message: "This is a log message")
+        logEvents.add(message: "This is another log message")
+        
+        logStream.sendEvents(events: logEvents) { error, resp in
+            XCTAssertNil(resp)
+            XCTAssertNil(error)
+        }
+        
+        XCTAssertTrue(logs.putEventsCalled)
+        XCTAssertNotNil(logs.putEventsRequest!)
+        XCTAssertEqual(logs.putEventsRequest?.logGroupName, group.name)
+        XCTAssertEqual(logs.putEventsRequest?.logStreamName, logStream.name)
+        XCTAssertEqual(logs.putEventsRequest?.logEvents?.count,2)
+        XCTAssertEqual(logs.putEventsRequest?.logEvents?[0].message, "This is a log message")
+        XCTAssertNotNil(logs.putEventsRequest?.logEvents?[0].timestamp)
+        XCTAssertEqual(logs.putEventsRequest?.logEvents?[1].message, "This is another log message")
+        XCTAssertNotNil(logs.putEventsRequest?.logEvents?[1].timestamp)
+    }
+
+    static var allTests = [
+        ("testInit", testInit),
+        ("testCreate", testCreate),
+        ("testSendEvents", testSendEvents)
+    ]
+
+}
+
+#endif

--- a/Tests/SwiftyBeaverTests/CloudWatch/CloudWatchLogsTests.swift
+++ b/Tests/SwiftyBeaverTests/CloudWatch/CloudWatchLogsTests.swift
@@ -1,0 +1,76 @@
+//
+//  CloudWatchLogsTests.swift
+//  SwiftyBeaver/CloudWatch
+//
+
+#if CLOUD_WATCH
+
+import Foundation
+import XCTest
+import AWSCore
+import AWSLogs
+@testable import SwiftyBeaver
+
+class CloudWatchLogsTests: XCTestCase {
+    var config: AWSServiceConfigMock! = nil
+    var awsConfiguration: AWSServiceConfiguration! = nil
+    var logs: CloudWatchLogs! = nil
+    
+    override func setUp() {
+        super.setUp()
+        config = AWSServiceConfigMock(cognitoPoolId: "12345", regionType: .USWest2).create()
+        awsConfiguration = config.configuration
+        logs = CloudWatchLogs(config: config, clientKey: "myClientKey")
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testInit() {
+        XCTAssertEqual(logs.clientKey, "myClientKey")
+        XCTAssertEqual(logs.configuration, awsConfiguration)
+    }
+    
+    func testInitialize() {
+        _ = logs.initialize()
+        XCTAssertEqual(logs.clientKey, "myClientKey")
+        XCTAssertEqual(logs.configuration, awsConfiguration)
+        XCTAssertNotNil(logs.logs)
+    }
+
+    func testCreateLogStream() {
+        _ = logs.initialize()
+        let logStreamRequest = AWSLogsCreateLogStreamRequest()!
+        logStreamRequest.logGroupName = "/my/group/name"
+        logStreamRequest.logStreamName = "/my/stream/name"
+        logs.createLogStream(logStreamRequest) { error in
+            XCTAssertNil(error)
+        }
+    }
+    
+    func testPutLogEvents() {
+        _ = logs.initialize()
+        let request = AWSLogsPutLogEventsRequest()!
+        request.logEvents = []
+        let event = AWSLogsInputLogEvent()!
+        event.message = "This is a log message"
+        event.timestamp = NSNumber(value: Date().timeIntervalSince1970 * 1000)
+        request.logEvents?.append(event)
+        logs.putLogEvents(request) { resp, error in
+            XCTAssertNil(resp)
+            XCTAssertNil(error)
+        }
+    }
+
+   
+    static var allTests = [
+        ("testInit", testInit),
+        ("testInitialize", testInitialize),
+        ("testCreateLogStream", testCreateLogStream),
+        ("testPutLogEvents", testPutLogEvents)
+    ]
+
+}
+
+#endif

--- a/Tests/SwiftyBeaverTests/CloudWatch/README.md
+++ b/Tests/SwiftyBeaverTests/CloudWatch/README.md
@@ -1,0 +1,13 @@
+# SwiftyBeaver/CloudWatch Tests
+
+The tests for SwiftyBeaver Cloudwatch are run as by Cocoapods in the iOS simulator.
+
+Use the following command to run them:
+
+
+``` Bash
+
+pod spec lint --subspec=CloudWatch --platforms=ios --verbose --allow-warnings
+
+```
+

--- a/Tests/SwiftyBeaverTests/CloudWatch/README.md
+++ b/Tests/SwiftyBeaverTests/CloudWatch/README.md
@@ -1,6 +1,6 @@
 # SwiftyBeaver/CloudWatch Tests
 
-The tests for SwiftyBeaver Cloudwatch are run as by Cocoapods in the iOS simulator.
+The tests for SwiftyBeaver Cloudwatch are run by Cocoapods in the iOS simulator.
 
 Use the following command to run them:
 

--- a/Tests/SwiftyBeaverTests/CloudWatch/mocks/AWSServiceConfigMock.swift
+++ b/Tests/SwiftyBeaverTests/CloudWatch/mocks/AWSServiceConfigMock.swift
@@ -1,0 +1,25 @@
+//
+//  AWSServiceConfigMock.swift
+//  SwiftyBeaver/CloudWatch
+//
+
+#if CLOUD_WATCH
+
+import Foundation
+import AWSCore
+import SwiftyBeaver
+
+public class AWSServiceConfigMock: AWSServiceConfig {
+    
+    override public init(cognitoPoolId: String, regionType: AWSRegionType) {
+        super.init(cognitoPoolId: cognitoPoolId, regionType: regionType)
+    }
+    
+    override public func create() -> AWSServiceConfigMock {
+        configuration = AWSServiceConfiguration(region: self.regionType, credentialsProvider:nil)
+        AWSServiceManager.default().defaultServiceConfiguration = configuration
+        return self
+    }
+}
+
+#endif

--- a/Tests/SwiftyBeaverTests/CloudWatch/mocks/CloudWatchLogsMock.swift
+++ b/Tests/SwiftyBeaverTests/CloudWatch/mocks/CloudWatchLogsMock.swift
@@ -1,0 +1,42 @@
+//
+//  CloudWatchLogsMock.swift
+//  SwiftyBeaver/CloudWatch
+//
+
+#if CLOUD_WATCH
+
+import Foundation
+import AWSCore
+import AWSLogs
+import SwiftyBeaver
+
+public class CloudWatchLogsMock: CloudWatchLogs {
+    var createLogStreamCalled = false
+    var createStreamRequest: AWSLogsCreateLogStreamRequest? = nil
+    var putEventsCalled = false
+    var putEventsRequest: AWSLogsPutLogEventsRequest? = nil
+    
+    override public init(config: AWSServiceConfig, clientKey: String) {
+        super.init(config: config, clientKey: clientKey)
+    }
+    
+    override public func initialize() -> CloudWatchLogsMock {
+        AWSLogs.register(with: configuration, forKey: clientKey)
+        logs = AWSLogs.default()
+        return self
+    }
+    
+    override public func createLogStream(_ request: AWSLogsCreateLogStreamRequest, completionHandler: ((Error?) -> Void)?) {
+        createLogStreamCalled = true
+        createStreamRequest = request
+        completionHandler?(nil)
+    }
+    
+    override public func putLogEvents(_ request: AWSLogsPutLogEventsRequest, completionHandler: ((AWSLogsPutLogEventsResponse?, Error?) -> Void)?) {
+        putEventsCalled = true
+        putEventsRequest = request
+        completionHandler?(nil, nil)
+    }
+}
+
+#endif


### PR DESCRIPTION
Added cloud watch support as a Cocoapod subspec.

NOTE:
AWSCore and AWSLogs dependencies only support iOS currently.
I have no experience with Carthage or other package managers, this supports Cocoapods only.
See the README under the CloudWatch dirs under Sources and SwiftyBeaverTests for usage and for doc on running the tests with Cocoapods.