### PR TITLE
Fix File Rotation

### DIFF
--- a/Sources/FileDestination.swift
+++ b/Sources/FileDestination.swift
@@ -128,7 +128,7 @@ open class FileDestination: BaseDestination {
        let lastIndex = (logFileAmount-1)
        let firstIndex = 1
        do {
-           for index in stride(from: lastIndex, to: firstIndex, by: -1) {
+           for index in stride(from: lastIndex, through: firstIndex, by: -1) {
                let oldFile = String.init(format: "%@.%d", filePath, index)
 
                if FileManager.default.fileExists(atPath: oldFile) {


### PR DESCRIPTION
The original code would skip the `.1` file since `stride(from: to: by:)` excludes the final index, `firstIndex`. 

If this file exists the last move operation would error out with 
```
rotateFile error: Error Domain=NSCocoaErrorDomain Code=516 "“logfile.log” couldn’t be moved to “logs” because an item with the same name already exists." UserInfo={NSSourceFilePathErrorKey=/var/mobile/Containers/Data/Application/975837DF-7FDA-41A9-8EEB-33A2948D35AB/Library/Application Support/logs/logfile.log, NSUserStringVariant=(
    Move
), NSDestinationFilePath=/var/mobile/Containers/Data/Application/975837DF-7FDA-41A9-8EEB-33A2948D35AB/Library/Application Support/logs/logfile.log.1, NSFilePath=/var/mobile/Containers/Data/Application/975837DF-7FDA-41A9-8EEB-33A2948D35AB/Library/Application Support/logs/logfile.log, NSUnderlyingError=0x2827d8e40 {Error Domain=NSPOSIXErrorDomain Code=17 "File exists"}}
```
essentially breaking all logging. 

This PR fixes that by using `stride(from:through:by:)` which includes the final index.