### PR TITLE
Allow subclassing of destinations

### DIFF
--- a/Sources/ConsoleDestination.swift
+++ b/Sources/ConsoleDestination.swift
@@ -9,7 +9,7 @@
 
 import Foundation
 
-public class ConsoleDestination: BaseDestination {
+open class ConsoleDestination: BaseDestination {
 
     /// use NSLog instead of print, default is false
     public var useNSLog = false
@@ -51,7 +51,7 @@ public class ConsoleDestination: BaseDestination {
     }
 
     // print to Xcode Console. uses full base class functionality
-    override public func send(_ level: SwiftyBeaver.Level, msg: String, thread: String,
+    override open func send(_ level: SwiftyBeaver.Level, msg: String, thread: String,
                                 file: String, function: String, line: Int, context: Any? = nil) -> String? {
         let formattedString = super.send(level, msg: msg, thread: thread, file: file, function: function, line: line, context: context)
 

--- a/Sources/FileDestination.swift
+++ b/Sources/FileDestination.swift
@@ -92,7 +92,7 @@ open class FileDestination: BaseDestination {
     }
 
     // append to file. uses full base class functionality
-    override public func send(_ level: SwiftyBeaver.Level, msg: String, thread: String,
+    override open func send(_ level: SwiftyBeaver.Level, msg: String, thread: String,
         file: String, function: String, line: Int, context: Any? = nil) -> String? {
         let formattedString = super.send(level, msg: msg, thread: thread, file: file, function: function, line: line, context: context)
 

--- a/Sources/SBPlatformDestination.swift
+++ b/Sources/SBPlatformDestination.swift
@@ -41,7 +41,7 @@ import FoundationNetworking
     let DEVICE_NAME = ""
 #endif
 
-public class SBPlatformDestination: BaseDestination {
+open class SBPlatformDestination: BaseDestination {
 
     public var appID = ""
     public var appSecret = ""
@@ -60,7 +60,7 @@ public class SBPlatformDestination: BaseDestination {
     }
     public var sendingPoints = SendingPoints()
     public var showNSLog = false // executes toNSLog statements to debug the class
-    var points = 0
+    public var points = 0
 
     public var serverURL = URL(string: "https://api.swiftybeaver.com/api/entries/") // optional
     public var entriesFileURL = URL(fileURLWithPath: "") // not optional
@@ -153,7 +153,7 @@ public class SBPlatformDestination: BaseDestination {
     }
 
     // append to file, each line is a JSON dict
-    override public func send(_ level: SwiftyBeaver.Level, msg: String, thread: String,
+    override open func send(_ level: SwiftyBeaver.Level, msg: String, thread: String,
         file: String, function: String, line: Int, context: Any? = nil) -> String? {
 
         var jsonString: String?


### PR DESCRIPTION
This PR sets the access levels of `ConsoleDestination`, `FileDestination`, and `SBPlatformDestination` to `open`, which allows for subclassing. I needed to modify the behavior of these destinations, for example, to add device-specific information when creating new log file entries. The most straightforward way to achieve this was to create a custom subclass and override the `send` method. But I'm also happy to discuss alternative approaches.