### PR TITLE
Fix write data crash

### DIFF
--- a/Sources/FileDestination.swift
+++ b/Sources/FileDestination.swift
@@ -194,7 +194,11 @@ open class FileDestination: BaseDestination {
 
                 let fileHandle = try FileHandle(forWritingTo: url)
                 fileHandle.seekToEndOfFile()
-                fileHandle.write(data)
+                if #available(iOS 13.4, *) {
+                    try fileHandle.write(contentsOf: data)
+                } else {
+                    fileHandle.write(data)
+                }
                 if syncAfterEachWrite {
                     fileHandle.synchronizeFile()
                 }


### PR DESCRIPTION
It will crash,  if no free space is left on the file system, or if any other writing error occurs. 
Here is the crash I met：
```
CrashDoctor Diagnosis: Application threw exception NSFileHandleOperationException: *** -[NSConcreteFileHandle writeData:]: No space left on device
Originated at or in a subcall of AudioFile<double>::getAiffSampleRate(std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >&, int)
Thread 16 Crashed:
0   CoreFoundation                      0x00000001aa421344 __exceptionPreprocess
1   libobjc.A.dylib                     0x00000001aa136cc0 objc_exception_throw
2   Foundation                          0x00000001aa7c4050 -[NSConcreteFileHandle readDataUpToLength:error:]
3   Foundation                          0x00000001aa74f504 -[NSConcreteFileHandle writeData:]
4   MyApp                              0x00000001035fa868 $s12SwiftyBeaver15FileDestinationC5write33_EECB18DCA187D4E49EF48E136B488AE7LL4data2toSb10Foundation4DataV_AH3URLVtFyALXEfU_
```