### PR TITLE
Remove anonymous parameters on file and function

### DIFF
--- a/Sources/SwiftyBeaver.swift
+++ b/Sources/SwiftyBeaver.swift
@@ -80,8 +80,8 @@ open class SwiftyBeaver {
     // MARK: Levels
 
     /// log something generally unimportant (lowest priority)
-    open class func verbose(_ message: @autoclosure () -> Any, _
-        file: String = #file, _ function: String = #function, line: Int = #line, context: Any? = nil) {
+    open class func verbose(_ message: @autoclosure () -> Any,
+        file: String = #file, function: String = #function, line: Int = #line, context: Any? = nil) {
         #if swift(>=5)
         custom(level: .verbose, message: message(), file: file, function: function, line: line, context: context)
         #else
@@ -90,8 +90,8 @@ open class SwiftyBeaver {
     }
 
     /// log something which help during debugging (low priority)
-    open class func debug(_ message: @autoclosure () -> Any, _
-        file: String = #file, _ function: String = #function, line: Int = #line, context: Any? = nil) {
+    open class func debug(_ message: @autoclosure () -> Any,
+        file: String = #file, function: String = #function, line: Int = #line, context: Any? = nil) {
         #if swift(>=5)
         custom(level: .debug, message: message(), file: file, function: function, line: line, context: context)
         #else
@@ -100,8 +100,8 @@ open class SwiftyBeaver {
     }
 
     /// log something which you are really interested but which is not an issue or error (normal priority)
-    open class func info(_ message: @autoclosure () -> Any, _
-        file: String = #file, _ function: String = #function, line: Int = #line, context: Any? = nil) {
+    open class func info(_ message: @autoclosure () -> Any,
+        file: String = #file, function: String = #function, line: Int = #line, context: Any? = nil) {
         #if swift(>=5)
         custom(level: .info, message: message(), file: file, function: function, line: line, context: context)
         #else
@@ -110,8 +110,8 @@ open class SwiftyBeaver {
     }
 
     /// log something which may cause big trouble soon (high priority)
-    open class func warning(_ message: @autoclosure () -> Any, _
-        file: String = #file, _ function: String = #function, line: Int = #line, context: Any? = nil) {
+    open class func warning(_ message: @autoclosure () -> Any,
+        file: String = #file, function: String = #function, line: Int = #line, context: Any? = nil) {
         #if swift(>=5)
         custom(level: .warning, message: message(), file: file, function: function, line: line, context: context)
         #else
@@ -120,8 +120,8 @@ open class SwiftyBeaver {
     }
 
     /// log something which will keep you awake at night (highest priority)
-    open class func error(_ message: @autoclosure () -> Any, _
-        file: String = #file, _ function: String = #function, line: Int = #line, context: Any? = nil) {
+    open class func error(_ message: @autoclosure () -> Any,
+        file: String = #file, function: String = #function, line: Int = #line, context: Any? = nil) {
         #if swift(>=5)
         custom(level: .error, message: message(), file: file, function: function, line: line, context: context)
         #else


### PR DESCRIPTION
I am unsure why those were anonymous parameters, but I feel like they shouldn't be, because it's very easy to produce unexpected results.

I certainly got surprised by this, until I looked at the source code.

----

I assume most people were using `print` statements prior to using a logger, where you would have:

```swift
print("Some error happened: ", error.localizedDescription)
print("Foo", "Bar", "FooBar")
```

If you replace the `print` statements with `log.debug`, the code will compile correctly.

```swift
log.debug("Some error happened: ", error.localizedDescription)
log.debug("Foo", "Bar", "FooBar")
```

But the 2nd and 3rd arguments will be passed as `file` and `function`, instead of the default values `#file` and `#function`

At least now, if you write code above, you will get a compiler error, which will hopefully trigger your WTF senses

![Screenshot 2022-12-31 at 18 05 33](https://user-images.githubusercontent.com/8976891/210150721-ab64805f-3484-4a6e-aca2-f89754e6b2ff.png)

