### PR TITLE
Remove second  `log.addDestination(console)` in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,6 @@ let log: SwiftyBeaver.Type = {
     console.format = "$DHH:mm:ss$d $L $M"
     // or use this for JSON output: console.format = "$J"
 
-    log.addDestination(console)
-
     // add the destinations to SwiftyBeaver
     log.addDestination(console)
     log.addDestination(file)


### PR DESCRIPTION
Heya, just going through the documentation and noticed there was two `log.addDestination(console)` in the documentation following https://github.com/SwiftyBeaver/SwiftyBeaver/pull/495. Thought it should be removed. Thanks!