### PR TITLE
Update README.md to demonstrate enabling OSLog printing in Xcode 15.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 #### In Xcode 15
 ```Swift
 let console = ConsoleDestination()
+// Note, this method relies on the OSLog API. If you do not want to use it, please replace it with .print.
 console.logPrintWay = .logger(subsystem: "Main", category: "UI")
 ```
 #### In Xcode 8
@@ -145,8 +146,10 @@ let file = FileDestination()  // log to default swiftybeaver.log file
 console.format = "$DHH:mm:ss$d $L $M"
 // or use this for JSON output: console.format = "$J"
 
-// In Xcode 15, specifying the logging method as .logger to display color, subsystem, and category information in the console.
+// In Xcode 15, specifying the logging method as .logger to display color, subsystem, and category information in the console.(Relies on the OSLog API)
 console.logPrintWay = .logger(subsystem: "Main", category: "UI")
+// If you prefer not to use the OSLog API, you can use print instead.
+// console.logPrintWay = .print 
 
 // add the destinations to SwiftyBeaver
 log.addDestination(console)
@@ -184,7 +187,6 @@ struct yourApp: App {
 
     init() {
         let console = ConsoleDestination()
-        console.logPrintWay = .logger(subsystem: "Main", category: "yourApp")
         logger.addDestination(console)
         // etc...
     }

--- a/README.md
+++ b/README.md
@@ -8,8 +8,15 @@
 
 ### During Development: Colored Logging to Xcode Console
 
-<img src="https://cloud.githubusercontent.com/assets/564725/18608323/ac065a98-7ce6-11e6-8e1b-2a062d54a1d5.png" width="608">
+<img width="924" alt="image" src="https://github.com/SwiftyBeaver/SwiftyBeaver/assets/15070906/418a6a70-ced4-4000-91c3-8dc8fc235b7c">
 
+
+#### In Xcode 15
+```Swift
+let console = ConsoleDestination()
+console.logPrintWay = .logger(subsystem: "Main", category: "UI")
+```
+#### In Xcode 8
 [Learn more](http://docs.swiftybeaver.com/article/9-log-to-xcode-console) about colored logging to Xcode 8 Console with Swift 3, 4 & 5. For Swift 2.3 [use this Gist](https://gist.github.com/skreutzberger/7c396573796473ed1be2c6d15cafed34). **No need to hack Xcode 8 anymore** to get color. You can even customize the log level word (ATTENTION instead of ERROR maybe?), the general amount of displayed data and if you want to use the 💜s or replace them with something else 😉
 
 <br/>
@@ -138,6 +145,9 @@ let file = FileDestination()  // log to default swiftybeaver.log file
 console.format = "$DHH:mm:ss$d $L $M"
 // or use this for JSON output: console.format = "$J"
 
+// In Xcode 15, specifying the logging method as .logger to display color, subsystem, and category information in the console.
+console.logPrintWay = .logger(subsystem: "Main", category: "UI")
+
 // add the destinations to SwiftyBeaver
 log.addDestination(console)
 log.addDestination(file)
@@ -174,6 +184,7 @@ struct yourApp: App {
 
     init() {
         let console = ConsoleDestination()
+        console.logPrintWay = .logger(subsystem: "Main", category: "yourApp")
         logger.addDestination(console)
         // etc...
     }


### PR DESCRIPTION
HI Every one:
I have updated the README to illustrate how to enable OSLog printing with color, subsystem, and category information in Xcode 15.
However, I haven't found a way to display colors when viewing files in the terminal. So I haven't replaced the second image.