### PR TITLE
Turn off privacy tracking

### DIFF
--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>NSPrivacyTracking</key>
-	<true/>
+	<false/>
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>


### PR DESCRIPTION
When the APP is reviewed, you will receive the following warning:

> ITMS-91064: Invalid tracking information - A PrivacyInfo.xcprivacy file contains invalid tracking information at the following path:
> "xxx/PrivacyInfo.xcprivacy". NSPrivacyTracking must be true if NSPrivacyTrackingDomains isn't empty. While no action is required at this time, starting May 1, 2024, when you upload a new app or app update, keys and values in your app's privacy manifest must be valid. For more details about privacy manifest files, visit:
> https://developer.apple.com/documentation/bundleresources/privacy_manifest_files.