### PR TITLE
Add Sendable support to SwiftyBeaver.Level

### DIFF
--- a/Sources/SwiftyBeaver.swift
+++ b/Sources/SwiftyBeaver.swift
@@ -244,3 +244,8 @@ open class SwiftyBeaver {
         return f
     }
 }
+
+// MARK: Sendable
+
+@available(iOS 8.0, macOS 10.10, tvOS 9.0, watchOS 2.0, *)
+extension SwiftyBeaver.Level: Sendable {}


### PR DESCRIPTION
Adding `Sendable` support to `SwiftyBeaver.Level`, so that we can use it in Swift 6 concurrency context.
