### PR TITLE
Update ConsoleDestination.swift: Replace hearts with squares fix #536

### DIFF
--- a/Sources/ConsoleDestination.swift
+++ b/Sources/ConsoleDestination.swift
@@ -46,13 +46,13 @@ open class ConsoleDestination: BaseDestination {
             } else {
                 // use colored Emojis for better visual distinction
                 // of log level for Xcode 8
-                levelColor.verbose = "💜 "     // purple
-                levelColor.debug = "💚 "        // green
-                levelColor.info = "💙 "         // blue
-                levelColor.warning = "💛 "     // yellow
-                levelColor.error = "❤️ "       // red
-                levelColor.critical = "❤️ "    // red
-                levelColor.fault = "❤️ "       // red
+                levelColor.verbose = "⬜️ "     // silver
+                levelColor.debug = "🟩 "        // green
+                levelColor.info = "🟦 "         // blue
+                levelColor.warning = "🟨 "     // yellow
+                levelColor.error = "🟥 "       // red
+                levelColor.critical = "🟥 "    // red
+                levelColor.fault = "🟥 "       // red
             }
         }
     }
@@ -61,13 +61,13 @@ open class ConsoleDestination: BaseDestination {
 
     public override init() {
         super.init()
-        levelColor.verbose = "💜 "     // purple
-        levelColor.debug = "💚 "        // green
-        levelColor.info = "💙 "         // blue
-        levelColor.warning = "💛 "     // yellow
-        levelColor.error = "❤️ "       // red
-        levelColor.critical = "❤️ "    // red
-        levelColor.fault = "❤️ "       // red
+        levelColor.verbose = "⬜️ "     // silver
+        levelColor.debug = "🟩 "        // green
+        levelColor.info = "🟦 "         // blue
+        levelColor.warning = "🟨 "     // yellow
+        levelColor.error = "🟥 "       // red
+        levelColor.critical = "🟥 "    // red
+        levelColor.fault = "🟥 "       // red
     }
 
     // print to Xcode Console. uses full base class functionality

--- a/Tests/SwiftyBeaverTests/ConsoleDestinationTests.swift
+++ b/Tests/SwiftyBeaverTests/ConsoleDestinationTests.swift
@@ -30,7 +30,7 @@ class ConsoleDestinationTests: XCTestCase {
 
         // default xcode colors
         XCTAssertFalse(console.useTerminalColors)
-        XCTAssertEqual(console.levelColor.verbose, "💜 ")
+        XCTAssertEqual(console.levelColor.verbose, "⬜️ ")
         XCTAssertEqual(console.reset, "")
         XCTAssertEqual(console.escape, "")
 


### PR DESCRIPTION
Replace hearts with squares.

I've matched the console destination so that the verbose is no longer purple but silver, as in the text-only mode.